### PR TITLE
CI: enable Codecov & docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,33 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - run: |
+          python-version: ${{ matrix.python-version }}
+      - name: Install test dependencies
+        run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install flake8 isort black pytest
-          ./scripts/checks.sh
+          pip install -r requirements.txt
+          pip install flake8 isort black pytest coverage
+      - name: Run checks
+        run: ./scripts/checks.sh
+      - name: Run tests with coverage
+        run: |
+          coverage run -m pytest
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: docs
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install doc dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+      - name: Build HTML docs with Sphinx (warnings as errors)
+        run: |
+          sphinx-build -b html -W docs docs/_build
+      - name: Upload built docs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dictionary.dic
 .venv/
 playwright-report/
 test-results/
+
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/wove/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/wove/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/wove/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/wove/actions/workflows/02-tests.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/wove/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/wove)
-[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/wove/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/wove/actions/workflows/03-docs.yml)
+[![codecov](https://codecov.io/gh/futuroptimist/wove/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/wove)
+[![docs](https://github.com/futuroptimist/wove/actions/workflows/docs.yml/badge.svg)](https://github.com/futuroptimist/wove/actions/workflows/docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/wove)](LICENSE)
 
 **wove** aims to provide an open-source toolkit for learning to knit and for building a robotic knitting machine. Documentation in `docs/` walks through the basics of hand knitting while the `cad/` directory contains OpenSCAD files for printable hardware components.

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -109,3 +109,5 @@ sugarkube
 DIY
 deps
 virtualenv
+maxdepth
+toctree

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Documentation
 
 - [Knitting Basics](knitting-basics.md)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "wove"
+
+extensions = [
+    "myst_parser",
+]
+
+html_theme = "furo"
+
+exclude_patterns = ["_build"]
+
+html_static_path = ["_static"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Documentation
+
+```{toctree}
+:maxdepth: 2
+
+knitting-basics
+robotic-knitting-machine
+styleguides/python
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=7
+furo
+myst-parser
+# docutils<0.18


### PR DESCRIPTION
## Summary
- generate coverage and upload to Codecov in CI
- build docs and save as an artifact
- ensure docs workflow passes by whitelisting Sphinx terms

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `sphinx-build -b html -W docs docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_687c7c14d5dc832fb36cae66cd930ae6