### PR TITLE
docs: add codex prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key features include:
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
+- Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,5 @@ orphan: true
 - [Crochet Guide](crochet-basics.md)
 - [Robotic Knitting Machine](robotic-knitting-machine.md)
 - [Python Style Guide](styleguides/python.md)
+- [Codex Prompt](prompts-codex.md)
+- [Codex CAD Prompt](prompts-codex-cad.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,6 @@ knitting-basics
 crochet-basics
 robotic-knitting-machine
 styleguides/python
+prompts-codex
+prompts-codex-cad
 ```

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex CAD Prompt'
+slug: 'prompts-codex-cad'
+---
+
+# Codex CAD Prompt
+
+Use this prompt when generating or updating OpenSCAD modules for Wove. It keeps
+3D assets and their exported models in sync.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository focused on 3D assets.
+
+PURPOSE:
+Maintain CAD sources and exported models.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- SCAD files live in `cad/` and STLs are committed alongside them.
+- Use `scripts/build_stl.sh` to regenerate models.
+
+REQUEST:
+1. Create or modify a `.scad` file under `cad/`.
+2. Run `scripts/build_stl.sh <file.scad>` to export the matching STL.
+3. Update documentation if the part changes.
+4. Verify `pre-commit run --all-files` and `pytest` pass.
+
+OUTPUT:
+A pull request summarizing CAD updates and test results.
+```

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,107 @@
+---
+title: 'Wove Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+Use this baseline prompt when asking an automated agent to contribute to the
+Wove repository. Keeping the instructions in version control helps the project
+maintain consistent guidelines over time.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `pre-commit run --all-files` and `pytest` succeed.
+- Run `./scripts/checks.sh` if additional validation is needed.
+
+REQUEST:
+1. Identify a straightforward improvement in code or docs.
+2. Implement the change using the existing project style.
+3. Update documentation when relevant.
+4. Execute the commands listed above.
+
+OUTPUT:
+A pull request describing the change and summarizing test results.
+```
+
+## Implementation prompts
+
+Copy **one** of the prompts below into Codex when you want the agent to make a
+specific improvement. Each prompt is file-scoped, single-purpose and
+actionable.
+
+### 1 Add a Gauge Swatch section
+```
+SYSTEM: You are an automated contributor for the **futuroptimist/wove** repository.
+
+GOAL
+Add a "Gauge Swatch" section to `docs/knitting-basics.md` explaining why gauge
+matters.
+
+FILES OF INTEREST
+- docs/knitting-basics.md
+
+REQUIREMENTS
+1. Use heading level `## Gauge` followed by a brief paragraph.
+2. Include a 3-step ordered list on knitting a gauge swatch.
+3. Keep line length ≤ 80 characters.
+
+ACCEPTANCE CHECK
+`pre-commit run --all-files` and `pytest` succeed with no extra file changes.
+
+OUTPUT
+Return only the diff.
+```
+
+### 2 Document `checks.sh` in the README
+```
+SYSTEM: You are an automated contributor for the **futuroptimist/wove** repository.
+
+GOAL
+Describe what `./scripts/checks.sh` does in the "Getting Started" section of
+`README.md`.
+
+FILES OF INTEREST
+- README.md
+
+REQUIREMENTS
+1. Mention that the script runs linting, tests and link checks.
+2. Keep bullet formatting consistent with existing style.
+3. Link to `scripts/checks.sh` using a relative path.
+
+ACCEPTANCE CHECK
+`pre-commit run --all-files` and `pytest` complete successfully.
+
+OUTPUT
+Return only the diff.
+```
+
+### 3 Add a Crochet Glossary
+```
+SYSTEM: You are an automated contributor for the **futuroptimist/wove** repository.
+
+GOAL
+Create a small glossary table in `docs/crochet-basics.md` defining "chain" and
+"slip stitch".
+
+FILES OF INTEREST
+- docs/crochet-basics.md
+
+REQUIREMENTS
+1. Insert a `## Glossary` section after "Foundational Knowledge".
+2. Use a Markdown table with headers `Term` and `Meaning`.
+3. Provide concise definitions for "chain" and "slip stitch".
+
+ACCEPTANCE CHECK
+`pre-commit run --all-files` and `pytest` run cleanly.
+
+OUTPUT
+Return only the diff.
+```


### PR DESCRIPTION
## Summary
- document a baseline Codex automation prompt and sample tasks for Wove
- add a CAD-focused Codex prompt for generating OpenSCAD modules and STL exports
- link Codex prompt docs from the README and docs index

## Testing
- `pre-commit run --all-files`
- `pytest`
- `sphinx-build -b html -W docs docs/_build`


------
https://chatgpt.com/codex/tasks/task_e_689067c8a39c832fa9f2a6f9d5fe0a7e