### PR TITLE
📝 docs: fix docs badge formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/wove/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/wove/actions/workflows/01-lint-format.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/wove/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/wove/actions/workflows/02-tests.yml)
 [![codecov](https://codecov.io/gh/futuroptimist/wove/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/wove)
-[![docs](https://github.com/futuroptimist/wove/actions/workflows/docs.yml/badge.svg)](https://github.com/futuroptimist/wove/actions/workflows/docs.yml)
+[![docs][docs-badge]][docs-workflow]
 [![License](https://img.shields.io/github/license/futuroptimist/wove)](LICENSE)
 
 **wove** aims to provide an open-source toolkit for learning to knit and crochet while building toward a robotic knitting machine. Documentation in `docs/` covers hand knitting and crochet basics, while the `cad/` directory contains OpenSCAD files for printable hardware components.
@@ -36,3 +36,6 @@ pip install -r requirements.txt
 ```
 
 See [AGENTS.md](AGENTS.md) for details on LLM helpers that keep this repo tidy. Contributions are welcome—see [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). For AI helper context see [llms.txt](llms.txt).
+
+[docs-badge]: https://github.com/futuroptimist/wove/actions/workflows/docs.yml/badge.svg
+[docs-workflow]: https://github.com/futuroptimist/wove/actions/workflows/docs.yml


### PR DESCRIPTION
## Summary
- use reference-style link for docs badge to avoid line wraps

## Testing
- `pre-commit run --all-files`
- `pytest`
- `./scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892df17bd20832faecba26b7f09393f