### PR TITLE
🧵 : add stitch gauge utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
+- Utility functions such as a stitch gauge calculator.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -13,3 +13,9 @@ This guide introduces the fundamentals of hand knitting with two standard needle
 4. **Bind off** to finish your piece.
 
 Continue experimenting with gauge and patterns as you grow more comfortable.
+
+```python
+from wove import stitches_per_inch
+
+stitches_per_inch(20, 4)  # 5.0 stitches per inch
+```

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -16,7 +16,7 @@ if [ -f package.json ]; then
 fi
 
 echo "Running tests"
-pytest -q
+python -m pytest -q
 
 # docs checks
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,9 +1,5 @@
-import sys
-from pathlib import Path
-
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from wove import stitches_per_inch
 
 

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from wove import stitches_per_inch
+
+
+def test_stitches_per_inch():
+    assert stitches_per_inch(20, 4) == 5.0
+
+
+def test_stitches_per_inch_invalid():
+    with pytest.raises(ValueError):
+        stitches_per_inch(10, 0)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,0 +1,3 @@
+from .gauge import stitches_per_inch
+
+__all__ = ["stitches_per_inch"]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def stitches_per_inch(stitches: int, inches: float) -> float:
+    """Return stitch gauge in stitches per inch.
+
+    Args:
+        stitches: Number of stitches across the swatch.
+        inches: Width of the swatch in inches. Must be > 0.
+
+    Returns:
+        Stitches per inch as a float.
+
+    Raises:
+        ValueError: If ``inches`` is not positive.
+    """
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    return stitches / inches


### PR DESCRIPTION
what: add stitches_per_inch helper and document usage
why: enable quick gauge calculations in code examples
how to test: pre-commit run --all-files && pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893e2b0394c832f945bd9ac905190f0