### PR TITLE
Add row gauge helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as a stitch gauge calculator.
+- Utility functions such as stitch and row gauge calculators.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -15,7 +15,8 @@ This guide introduces the fundamentals of hand knitting with two standard needle
 Continue experimenting with gauge and patterns as you grow more comfortable.
 
 ```python
-from wove import stitches_per_inch
+from wove import rows_per_inch, stitches_per_inch
 
 stitches_per_inch(20, 4)  # 5.0 stitches per inch
+rows_per_inch(30, 4)  # 7.5 rows per inch
 ```

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,6 +1,6 @@
 import pytest
 
-from wove import stitches_per_inch
+from wove import rows_per_inch, stitches_per_inch
 
 
 def test_stitches_per_inch():
@@ -10,3 +10,12 @@ def test_stitches_per_inch():
 def test_stitches_per_inch_invalid():
     with pytest.raises(ValueError):
         stitches_per_inch(10, 0)
+
+
+def test_rows_per_inch():
+    assert rows_per_inch(30, 4) == 7.5
+
+
+def test_rows_per_inch_invalid():
+    with pytest.raises(ValueError):
+        rows_per_inch(10, 0)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,3 +1,3 @@
-from .gauge import stitches_per_inch
+from .gauge import rows_per_inch, stitches_per_inch
 
-__all__ = ["stitches_per_inch"]
+__all__ = ["stitches_per_inch", "rows_per_inch"]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -17,3 +17,21 @@ def stitches_per_inch(stitches: int, inches: float) -> float:
     if inches <= 0:
         raise ValueError("inches must be positive")
     return stitches / inches
+
+
+def rows_per_inch(rows: int, inches: float) -> float:
+    """Return row gauge in rows per inch.
+
+    Args:
+        rows: Number of rows across the swatch.
+        inches: Height of the swatch in inches. Must be > 0.
+
+    Returns:
+        Rows per inch as a float.
+
+    Raises:
+        ValueError: If ``inches`` is not positive.
+    """
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    return rows / inches


### PR DESCRIPTION
What: add rows_per_inch helper, export, docs, tests.
Why: compute row gauge.
How to test: pre-commit run --all-files; PYTHONPATH=. pytest
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_6894377dd204832fa68466fec9b5bc55