### PR TITLE
🧹 : sort imports – fix lint

### DIFF
--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,11 +1,6 @@
 import pytest
 
-from wove import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 
 def test_stitches_per_inch():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,4 +1,9 @@
-from .gauge import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
+from .gauge import (
+    rows_per_cm,
+    rows_per_inch,
+    stitches_per_cm,
+    stitches_per_inch,
+)
 
 __all__ = [
     "stitches_per_inch",

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,9 +1,4 @@
-from .gauge import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from .gauge import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 __all__ = [
     "stitches_per_inch",


### PR DESCRIPTION
what: reorder imports in package and tests to satisfy lint
why: fix failing isort/black checks in CI
how to test: pre-commit run --all-files && pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895927561ec832f9341784949fe786b