### PR TITLE
🐛 : – enforce positive gauge inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters.
+- Utility functions such as stitch and row gauge calculators for inches and centimeters,
+  with input validation.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -27,3 +27,5 @@ rows_per_inch(30, 4)  # 7.5 rows per inch
 stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
 ```
+
+These helpers validate that stitch, row, and measurement inputs are positive values.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,11 +1,6 @@
 import pytest
 
-from wove import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 
 def test_stitches_per_inch():
@@ -17,6 +12,12 @@ def test_stitches_per_inch_invalid():
         stitches_per_inch(10, 0)
 
 
+@pytest.mark.parametrize("count", [0, -1])
+def test_stitches_per_inch_invalid_stitches(count):
+    with pytest.raises(ValueError):
+        stitches_per_inch(count, 4)
+
+
 def test_rows_per_inch():
     assert rows_per_inch(30, 4) == 7.5
 
@@ -24,6 +25,12 @@ def test_rows_per_inch():
 def test_rows_per_inch_invalid():
     with pytest.raises(ValueError):
         rows_per_inch(10, 0)
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_rows_per_inch_invalid_rows(count):
+    with pytest.raises(ValueError):
+        rows_per_inch(count, 4)
 
 
 def test_stitches_per_cm():
@@ -35,6 +42,12 @@ def test_stitches_per_cm_invalid():
         stitches_per_cm(10, 0)
 
 
+@pytest.mark.parametrize("count", [0, -1])
+def test_stitches_per_cm_invalid_stitches(count):
+    with pytest.raises(ValueError):
+        stitches_per_cm(count, 10)
+
+
 def test_rows_per_cm():
     assert rows_per_cm(30, 10) == 3.0
 
@@ -42,3 +55,9 @@ def test_rows_per_cm():
 def test_rows_per_cm_invalid():
     with pytest.raises(ValueError):
         rows_per_cm(10, 0)
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_rows_per_cm_invalid_rows(count):
+    with pytest.raises(ValueError):
+        rows_per_cm(count, 10)

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,21 +1,27 @@
 from __future__ import annotations
 
 
+def _validate_positive(value: float | int, name: str) -> None:
+    """Raise ``ValueError`` if *value* is not positive."""
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+
+
 def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         inches: Width of the swatch in inches. Must be > 0.
 
     Returns:
         Stitches per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``stitches`` or ``inches`` is not positive.
     """
-    if inches <= 0:
-        raise ValueError("inches must be positive")
+    _validate_positive(stitches, "stitches")
+    _validate_positive(inches, "inches")
     return stitches / inches
 
 
@@ -23,17 +29,17 @@ def rows_per_inch(rows: int, inches: float) -> float:
     """Return row gauge in rows per inch.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         inches: Height of the swatch in inches. Must be > 0.
 
     Returns:
         Rows per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``rows`` or ``inches`` is not positive.
     """
-    if inches <= 0:
-        raise ValueError("inches must be positive")
+    _validate_positive(rows, "rows")
+    _validate_positive(inches, "inches")
     return rows / inches
 
 
@@ -41,17 +47,17 @@ def stitches_per_cm(stitches: int, cm: float) -> float:
     """Return stitch gauge in stitches per centimeter.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         cm: Width of the swatch in centimeters. Must be > 0.
 
     Returns:
         Stitches per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``stitches`` or ``cm`` is not positive.
     """
-    if cm <= 0:
-        raise ValueError("cm must be positive")
+    _validate_positive(stitches, "stitches")
+    _validate_positive(cm, "cm")
     return stitches / cm
 
 
@@ -59,15 +65,15 @@ def rows_per_cm(rows: int, cm: float) -> float:
     """Return row gauge in rows per centimeter.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         cm: Height of the swatch in centimeters. Must be > 0.
 
     Returns:
         Rows per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``rows`` or ``cm`` is not positive.
     """
-    if cm <= 0:
-        raise ValueError("cm must be positive")
+    _validate_positive(rows, "rows")
+    _validate_positive(cm, "cm")
     return rows / cm


### PR DESCRIPTION
what: validate stitch and row counts in gauge helpers and docs
why: avoid nonsensical results from zero or negative values
how to test: pre-commit run --all-files && pytest

------
https://chatgpt.com/codex/tasks/task_e_6896ce4a0354832fb99c40532a91caea