### PR TITLE
Validate gauge input counts

### DIFF
--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -27,3 +27,6 @@ rows_per_inch(30, 4)  # 7.5 rows per inch
 stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
 ```
+
+All gauge helpers require positive stitch and row counts and positive measurements.
+Passing non-positive values raises ``ValueError``.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,44 +1,59 @@
 import pytest
 
-from wove import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 
 def test_stitches_per_inch():
     assert stitches_per_inch(20, 4) == 5.0
 
 
-def test_stitches_per_inch_invalid():
+def test_stitches_per_inch_invalid_inches():
     with pytest.raises(ValueError):
         stitches_per_inch(10, 0)
+
+
+def test_stitches_per_inch_invalid_stitches():
+    with pytest.raises(ValueError):
+        stitches_per_inch(0, 4)
 
 
 def test_rows_per_inch():
     assert rows_per_inch(30, 4) == 7.5
 
 
-def test_rows_per_inch_invalid():
+def test_rows_per_inch_invalid_inches():
     with pytest.raises(ValueError):
         rows_per_inch(10, 0)
+
+
+def test_rows_per_inch_invalid_rows():
+    with pytest.raises(ValueError):
+        rows_per_inch(0, 4)
 
 
 def test_stitches_per_cm():
     assert stitches_per_cm(20, 10) == 2.0
 
 
-def test_stitches_per_cm_invalid():
+def test_stitches_per_cm_invalid_cm():
     with pytest.raises(ValueError):
         stitches_per_cm(10, 0)
+
+
+def test_stitches_per_cm_invalid_stitches():
+    with pytest.raises(ValueError):
+        stitches_per_cm(0, 10)
 
 
 def test_rows_per_cm():
     assert rows_per_cm(30, 10) == 3.0
 
 
-def test_rows_per_cm_invalid():
+def test_rows_per_cm_invalid_cm():
     with pytest.raises(ValueError):
         rows_per_cm(10, 0)
+
+
+def test_rows_per_cm_invalid_rows():
+    with pytest.raises(ValueError):
+        rows_per_cm(0, 10)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 from .gauge import (
     rows_per_cm,
     rows_per_inch,

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -5,15 +5,17 @@ def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         inches: Width of the swatch in inches. Must be > 0.
 
     Returns:
         Stitches per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``stitches`` or ``inches`` is not positive.
     """
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
     return stitches / inches
@@ -23,15 +25,17 @@ def rows_per_inch(rows: int, inches: float) -> float:
     """Return row gauge in rows per inch.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         inches: Height of the swatch in inches. Must be > 0.
 
     Returns:
         Rows per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``rows`` or ``inches`` is not positive.
     """
+    if rows <= 0:
+        raise ValueError("rows must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
     return rows / inches
@@ -41,15 +45,17 @@ def stitches_per_cm(stitches: int, cm: float) -> float:
     """Return stitch gauge in stitches per centimeter.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         cm: Width of the swatch in centimeters. Must be > 0.
 
     Returns:
         Stitches per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``stitches`` or ``cm`` is not positive.
     """
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
     return stitches / cm
@@ -59,15 +65,17 @@ def rows_per_cm(rows: int, cm: float) -> float:
     """Return row gauge in rows per centimeter.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         cm: Height of the swatch in centimeters. Must be > 0.
 
     Returns:
         Rows per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``rows`` or ``cm`` is not positive.
     """
+    if rows <= 0:
+        raise ValueError("rows must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
     return rows / cm


### PR DESCRIPTION
## Summary
- ensure gauge functions reject non-positive stitch or row values
- document positive input requirements in knitting guide
- cover invalid counts in gauge tests

## Testing
- `pre-commit run --all-files`
- `pytest`
- `bash scripts/checks.sh`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ce4a0354832fb99c40532a91caea