### PR TITLE
🧵 : validate gauge counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters.
+- Utility functions such as stitch and row gauge calculators for inches and centimeters that validate positive inputs.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -17,6 +17,11 @@ def test_stitches_per_inch_invalid():
         stitches_per_inch(10, 0)
 
 
+def test_stitches_per_inch_negative_stitches():
+    with pytest.raises(ValueError):
+        stitches_per_inch(-10, 4)
+
+
 def test_rows_per_inch():
     assert rows_per_inch(30, 4) == 7.5
 
@@ -24,6 +29,11 @@ def test_rows_per_inch():
 def test_rows_per_inch_invalid():
     with pytest.raises(ValueError):
         rows_per_inch(10, 0)
+
+
+def test_rows_per_inch_negative_rows():
+    with pytest.raises(ValueError):
+        rows_per_inch(-10, 4)
 
 
 def test_stitches_per_cm():
@@ -35,6 +45,11 @@ def test_stitches_per_cm_invalid():
         stitches_per_cm(10, 0)
 
 
+def test_stitches_per_cm_negative_stitches():
+    with pytest.raises(ValueError):
+        stitches_per_cm(-10, 10)
+
+
 def test_rows_per_cm():
     assert rows_per_cm(30, 10) == 3.0
 
@@ -42,3 +57,8 @@ def test_rows_per_cm():
 def test_rows_per_cm_invalid():
     with pytest.raises(ValueError):
         rows_per_cm(10, 0)
+
+
+def test_rows_per_cm_negative_rows():
+    with pytest.raises(ValueError):
+        rows_per_cm(-10, 10)

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -5,15 +5,17 @@ def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         inches: Width of the swatch in inches. Must be > 0.
 
     Returns:
         Stitches per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``stitches`` or ``inches`` is not positive.
     """
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
     return stitches / inches
@@ -23,15 +25,17 @@ def rows_per_inch(rows: int, inches: float) -> float:
     """Return row gauge in rows per inch.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         inches: Height of the swatch in inches. Must be > 0.
 
     Returns:
         Rows per inch as a float.
 
     Raises:
-        ValueError: If ``inches`` is not positive.
+        ValueError: If ``rows`` or ``inches`` is not positive.
     """
+    if rows <= 0:
+        raise ValueError("rows must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
     return rows / inches
@@ -41,15 +45,17 @@ def stitches_per_cm(stitches: int, cm: float) -> float:
     """Return stitch gauge in stitches per centimeter.
 
     Args:
-        stitches: Number of stitches across the swatch.
+        stitches: Number of stitches across the swatch. Must be > 0.
         cm: Width of the swatch in centimeters. Must be > 0.
 
     Returns:
         Stitches per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``stitches`` or ``cm`` is not positive.
     """
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
     return stitches / cm
@@ -59,15 +65,17 @@ def rows_per_cm(rows: int, cm: float) -> float:
     """Return row gauge in rows per centimeter.
 
     Args:
-        rows: Number of rows across the swatch.
+        rows: Number of rows across the swatch. Must be > 0.
         cm: Height of the swatch in centimeters. Must be > 0.
 
     Returns:
         Rows per centimeter as a float.
 
     Raises:
-        ValueError: If ``cm`` is not positive.
+        ValueError: If ``rows`` or ``cm`` is not positive.
     """
+    if rows <= 0:
+        raise ValueError("rows must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
     return rows / cm


### PR DESCRIPTION
## Summary
- ensure gauge helpers raise ValueError for non-positive stitches and rows
- document input validation

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ce4a0354832fb99c40532a91caea