### PR TITLE
📐 : add calibration cube model

### DIFF
--- a/cad/calibration_cube.scad
+++ b/cad/calibration_cube.scad
@@ -1,0 +1,2 @@
+// Calibration cube: 20 mm test block for printer calibration
+cube([20, 20, 20]);

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -7,5 +7,6 @@ The long-term goal of this project is to develop a DIY robotic system that autom
 - **Stepper mount** – secures a motor for precise control.
 - **Carriage** – moves the working yarn and needles according to instructions.
 - **Spacer** – maintains consistent gaps between components.
+- **Calibration cube** – simple 20 mm block for printer calibration.
 
 Generated G-code or custom instructions will drive these parts to knit automatically.

--- a/stl/calibration_cube.stl
+++ b/stl/calibration_cube.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -0 0 1
+    outer loop
+      vertex 0 20 20
+      vertex 20 0 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20 0 20
+      vertex 0 20 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 20 20 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20 20 0
+      vertex 0 0 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 20
+      vertex 0 0 20
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 20 0 20
+      vertex 0 0 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 20 0 20
+      vertex 20 20 0
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 20 0
+      vertex 20 0 20
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20 20 0
+      vertex 0 20 20
+      vertex 20 20 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 20
+      vertex 20 20 0
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 20
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 20 20
+      vertex 0 0 0
+      vertex 0 0 20
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
what: add 20 mm calibration cube SCAD, STL, and docs
why: provide simple block for printer calibration
how to test:
- scripts/build_stl.sh cad/calibration_cube.scad
- pre-commit run --all-files
- pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896ce4272b0832f89f7d50e3b4d1304