### PR TITLE
✨ Add yarn guide CAD model

### DIFF
--- a/cad/yarn_guide.scad
+++ b/cad/yarn_guide.scad
@@ -1,0 +1,11 @@
+// Simple yarn guide ring with slot for threading
+module yarn_guide(radius=10, thickness=2, slot_width=4) {
+    difference() {
+        cylinder(h=5, r=radius + thickness);
+        cylinder(h=5, r=radius);
+        translate([radius, -slot_width/2, -1])
+            cube([radius + thickness, slot_width, 7]);
+    }
+}
+
+yarn_guide();

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -7,5 +7,6 @@ The long-term goal of this project is to develop a DIY robotic system that autom
 - **Stepper mount** – secures a motor for precise control.
 - **Carriage** – moves the working yarn and needles according to instructions.
 - **Spacer** – maintains consistent gaps between components.
+- **Yarn guide** – directs yarn through the system and helps maintain tension.
 
 Generated G-code or custom instructions will drive these parts to knit automatically.

--- a/stl/yarn_guide.stl
+++ b/stl/yarn_guide.stl
@@ -1,0 +1,1766 @@
+solid OpenSCAD_Model
+  facet normal 0.406745 0.913542 -0
+    outer loop
+      vertex 6 10.3923 0
+      vertex 3.7082 11.4127 5
+      vertex 6 10.3923 5
+    endloop
+  endfacet
+  facet normal 0.406745 0.913542 0
+    outer loop
+      vertex 3.7082 11.4127 5
+      vertex 6 10.3923 0
+      vertex 3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal 0.951048 0.309044 0
+    outer loop
+      vertex 11.7378 2.49494 5
+      vertex 10.9625 4.88084 0
+      vertex 10.9625 4.88084 5
+    endloop
+  endfacet
+  facet normal 0.951048 0.309044 0
+    outer loop
+      vertex 10.9625 4.88084 0
+      vertex 11.7378 2.49494 5
+      vertex 11.7378 2.49494 0
+    endloop
+  endfacet
+  facet normal 0.994526 0.104488 0
+    outer loop
+      vertex 11.7898 2 5
+      vertex 11.7378 2.49494 0
+      vertex 11.7378 2.49494 5
+    endloop
+  endfacet
+  facet normal 0.994526 0.104488 0
+    outer loop
+      vertex 11.7378 2.49494 0
+      vertex 11.7898 2 5
+      vertex 11.7898 2 0
+    endloop
+  endfacet
+  facet normal 0.866032 0.499988 0
+    outer loop
+      vertex 10.9625 4.88084 5
+      vertex 9.7082 7.05342 0
+      vertex 9.7082 7.05342 5
+    endloop
+  endfacet
+  facet normal 0.866032 0.499988 0
+    outer loop
+      vertex 9.7082 7.05342 0
+      vertex 10.9625 4.88084 5
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309044 0
+    outer loop
+      vertex 10.9625 -4.88084 5
+      vertex 11.7378 -2.49494 0
+      vertex 11.7378 -2.49494 5
+    endloop
+  endfacet
+  facet normal 0.951048 -0.309044 0
+    outer loop
+      vertex 11.7378 -2.49494 0
+      vertex 10.9625 -4.88084 5
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -2 0
+      vertex 11.7378 -2.49494 0
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7378 -2.49494 0
+      vertex 10 -2 0
+      vertex 11.7898 -2 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10 -2 0
+      vertex 9.78148 -2.07912 0
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.13545 -4.06737 0
+      vertex 10 -2 0
+      vertex 10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.13545 -4.06737 0
+      vertex 10.9625 -4.88084 0
+      vertex 9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -2 0
+      vertex 9.13545 -4.06737 0
+      vertex 9.78148 -2.07912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.7082 -7.05342 0
+      vertex 8.09017 -5.87785 0
+      vertex 9.13545 -4.06737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 8.09017 -5.87785 0
+      vertex 9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.02957 -8.91774 0
+      vertex 6.69131 -7.43145 0
+      vertex 8.09017 -5.87785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 -10.3923 0
+      vertex 6.69131 -7.43145 0
+      vertex 8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 -10.3923 0
+      vertex 5 -8.66025 0
+      vertex 6.69131 -7.43145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.7082 -11.4127 0
+      vertex 5 -8.66025 0
+      vertex 6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.7082 -11.4127 0
+      vertex 3.09017 -9.51056 0
+      vertex 5 -8.66025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex 3.09017 -9.51056 0
+      vertex 3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex 1.04528 -9.94522 0
+      vertex 3.09017 -9.51056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex -1.04528 -9.94522 0
+      vertex 1.04528 -9.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25434 -11.9343 0
+      vertex -1.04528 -9.94522 0
+      vertex 1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25434 -11.9343 0
+      vertex -3.09017 -9.51056 0
+      vertex -1.04528 -9.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.7082 -11.4127 0
+      vertex -3.09017 -9.51056 0
+      vertex -1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.7082 -11.4127 0
+      vertex -5 -8.66025 0
+      vertex -3.09017 -9.51056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6 -10.3923 0
+      vertex -5 -8.66025 0
+      vertex -3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6 -10.3923 0
+      vertex -6.69131 -7.43145 0
+      vertex -5 -8.66025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -6.69131 -7.43145 0
+      vertex -6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -8.09017 -5.87785 0
+      vertex -6.69131 -7.43145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.7082 -7.05342 0
+      vertex -8.09017 -5.87785 0
+      vertex -8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.09017 -5.87785 0
+      vertex -9.7082 -7.05342 0
+      vertex -9.13545 -4.06737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9625 -4.88084 0
+      vertex -9.13545 -4.06737 0
+      vertex -9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.13545 -4.06737 0
+      vertex -10.9625 -4.88084 0
+      vertex -9.78148 -2.07912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7378 -2.49494 0
+      vertex -9.78148 -2.07912 0
+      vertex -10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 0
+      vertex 9.78148 2.07912 0
+      vertex 10 2 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 2 0
+      vertex 11.7378 2.49494 0
+      vertex 11.7898 2 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.7378 2.49494 0
+      vertex 10 2 0
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.13545 4.06737 0
+      vertex 10 2 0
+      vertex 9.78148 2.07912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 2 0
+      vertex 9.13545 4.06737 0
+      vertex 10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.9625 4.88084 0
+      vertex 9.13545 4.06737 0
+      vertex 9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.09017 5.87785 0
+      vertex 9.7082 7.05342 0
+      vertex 9.13545 4.06737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.09017 5.87785 0
+      vertex 8.02957 8.91774 0
+      vertex 9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.69131 7.43145 0
+      vertex 8.02957 8.91774 0
+      vertex 8.09017 5.87785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.69131 7.43145 0
+      vertex 6 10.3923 0
+      vertex 8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 8.66025 0
+      vertex 6 10.3923 0
+      vertex 6.69131 7.43145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5 8.66025 0
+      vertex 3.7082 11.4127 0
+      vertex 6 10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.09017 9.51056 0
+      vertex 3.7082 11.4127 0
+      vertex 5 8.66025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.09017 9.51056 0
+      vertex 1.25434 11.9343 0
+      vertex 3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.04528 9.94522 0
+      vertex 1.25434 11.9343 0
+      vertex 3.09017 9.51056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.04528 9.94522 0
+      vertex 1.25434 11.9343 0
+      vertex 1.04528 9.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.04528 9.94522 0
+      vertex -1.25434 11.9343 0
+      vertex 1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.09017 9.51056 0
+      vertex -1.25434 11.9343 0
+      vertex -1.04528 9.94522 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.09017 9.51056 0
+      vertex -3.7082 11.4127 0
+      vertex -1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5 8.66025 0
+      vertex -3.7082 11.4127 0
+      vertex -3.09017 9.51056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5 8.66025 0
+      vertex -6 10.3923 0
+      vertex -3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.69131 7.43145 0
+      vertex -6 10.3923 0
+      vertex -5 8.66025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.69131 7.43145 0
+      vertex -8.02957 8.91774 0
+      vertex -6 10.3923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.09017 5.87785 0
+      vertex -8.02957 8.91774 0
+      vertex -6.69131 7.43145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.7082 7.05342 0
+      vertex -8.09017 5.87785 0
+      vertex -9.13545 4.06737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.09017 5.87785 0
+      vertex -9.7082 7.05342 0
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9625 4.88084 0
+      vertex -9.13545 4.06737 0
+      vertex -9.78148 2.07912 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7378 2.49494 0
+      vertex -9.78148 2.07912 0
+      vertex -10 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.78148 -2.07912 0
+      vertex -11.7378 -2.49494 0
+      vertex -10 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.13545 4.06737 0
+      vertex -10.9625 4.88084 0
+      vertex -9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12 0 0
+      vertex -10 0 0
+      vertex -11.7378 -2.49494 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.78148 2.07912 0
+      vertex -11.7378 2.49494 0
+      vertex -10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 0
+      vertex -12 0 0
+      vertex -11.7378 2.49494 0
+    endloop
+  endfacet
+  facet normal 0.207918 -0.978146 0
+    outer loop
+      vertex 1.25434 -11.9343 0
+      vertex 3.7082 -11.4127 5
+      vertex 1.25434 -11.9343 5
+    endloop
+  endfacet
+  facet normal 0.207918 -0.978146 0
+    outer loop
+      vertex 3.7082 -11.4127 5
+      vertex 1.25434 -11.9343 0
+      vertex 3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0.743147 0.669128 0
+    outer loop
+      vertex 9.7082 7.05342 5
+      vertex 8.02957 8.91774 0
+      vertex 8.02957 8.91774 5
+    endloop
+  endfacet
+  facet normal 0.743147 0.669128 0
+    outer loop
+      vertex 8.02957 8.91774 0
+      vertex 9.7082 7.05342 5
+      vertex 9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669128 0
+    outer loop
+      vertex 8.02957 -8.91774 5
+      vertex 9.7082 -7.05342 0
+      vertex 9.7082 -7.05342 5
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669128 0
+    outer loop
+      vertex 9.7082 -7.05342 0
+      vertex 8.02957 -8.91774 5
+      vertex 8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309044 0
+    outer loop
+      vertex -10.9625 -4.88084 0
+      vertex -11.7378 -2.49494 5
+      vertex -11.7378 -2.49494 0
+    endloop
+  endfacet
+  facet normal -0.951048 -0.309044 0
+    outer loop
+      vertex -11.7378 -2.49494 5
+      vertex -10.9625 -4.88084 0
+      vertex -10.9625 -4.88084 5
+    endloop
+  endfacet
+  facet normal 0.866032 -0.499988 0
+    outer loop
+      vertex 9.7082 -7.05342 5
+      vertex 10.9625 -4.88084 0
+      vertex 10.9625 -4.88084 5
+    endloop
+  endfacet
+  facet normal 0.866032 -0.499988 0
+    outer loop
+      vertex 10.9625 -4.88084 0
+      vertex 9.7082 -7.05342 5
+      vertex 9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal -0.406745 0.913542 0
+    outer loop
+      vertex -3.7082 11.4127 0
+      vertex -6 10.3923 5
+      vertex -3.7082 11.4127 5
+    endloop
+  endfacet
+  facet normal -0.406745 0.913542 0
+    outer loop
+      vertex -6 10.3923 5
+      vertex -3.7082 11.4127 0
+      vertex -6 10.3923 0
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -6 10.3923 0
+      vertex -8.02957 8.91774 5
+      vertex -6 10.3923 5
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex -8.02957 8.91774 5
+      vertex -6 10.3923 0
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669128 0
+    outer loop
+      vertex -9.7082 7.05342 0
+      vertex -8.02957 8.91774 5
+      vertex -8.02957 8.91774 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669128 0
+    outer loop
+      vertex -8.02957 8.91774 5
+      vertex -9.7082 7.05342 0
+      vertex -9.7082 7.05342 5
+    endloop
+  endfacet
+  facet normal -0.866032 0.499988 0
+    outer loop
+      vertex -10.9625 4.88084 0
+      vertex -9.7082 7.05342 5
+      vertex -9.7082 7.05342 0
+    endloop
+  endfacet
+  facet normal -0.866032 0.499988 0
+    outer loop
+      vertex -9.7082 7.05342 5
+      vertex -10.9625 4.88084 0
+      vertex -10.9625 4.88084 5
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 6 -10.3923 0
+      vertex 8.02957 -8.91774 5
+      vertex 6 -10.3923 5
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex 8.02957 -8.91774 5
+      vertex 6 -10.3923 0
+      vertex 8.02957 -8.91774 0
+    endloop
+  endfacet
+  facet normal 0.207918 0.978146 -0
+    outer loop
+      vertex 3.7082 11.4127 0
+      vertex 1.25434 11.9343 5
+      vertex 3.7082 11.4127 5
+    endloop
+  endfacet
+  facet normal 0.207918 0.978146 0
+    outer loop
+      vertex 1.25434 11.9343 5
+      vertex 3.7082 11.4127 0
+      vertex 1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104517 0
+    outer loop
+      vertex -11.7378 -2.49494 0
+      vertex -12 0 5
+      vertex -12 0 0
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104517 0
+    outer loop
+      vertex -12 0 5
+      vertex -11.7378 -2.49494 0
+      vertex -11.7378 -2.49494 5
+    endloop
+  endfacet
+  facet normal 0.994526 -0.104488 0
+    outer loop
+      vertex 11.7378 -2.49494 5
+      vertex 11.7898 -2 0
+      vertex 11.7898 -2 5
+    endloop
+  endfacet
+  facet normal 0.994526 -0.104488 0
+    outer loop
+      vertex 11.7898 -2 0
+      vertex 11.7378 -2.49494 5
+      vertex 11.7378 -2.49494 0
+    endloop
+  endfacet
+  facet normal -0.866032 -0.499988 0
+    outer loop
+      vertex -9.7082 -7.05342 0
+      vertex -10.9625 -4.88084 5
+      vertex -10.9625 -4.88084 0
+    endloop
+  endfacet
+  facet normal -0.866032 -0.499988 0
+    outer loop
+      vertex -10.9625 -4.88084 5
+      vertex -9.7082 -7.05342 0
+      vertex -9.7082 -7.05342 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 2 5
+      vertex 11.7378 2.49494 5
+      vertex 10.9625 4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7378 2.49494 5
+      vertex 10 2 5
+      vertex 11.7898 2 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 2 5
+      vertex 9.78148 2.07912 5
+      vertex 10 0 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.13545 4.06737 5
+      vertex 10 2 5
+      vertex 10.9625 4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.13545 4.06737 5
+      vertex 10.9625 4.88084 5
+      vertex 9.7082 7.05342 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 2 5
+      vertex 9.13545 4.06737 5
+      vertex 9.78148 2.07912 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.7082 7.05342 5
+      vertex 8.09017 5.87785 5
+      vertex 9.13545 4.06737 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02957 8.91774 5
+      vertex 8.09017 5.87785 5
+      vertex 9.7082 7.05342 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02957 8.91774 5
+      vertex 6.69131 7.43145 5
+      vertex 8.09017 5.87785 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 10.3923 5
+      vertex 6.69131 7.43145 5
+      vertex 8.02957 8.91774 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 10.3923 5
+      vertex 5 8.66025 5
+      vertex 6.69131 7.43145 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.7082 11.4127 5
+      vertex 5 8.66025 5
+      vertex 6 10.3923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.7082 11.4127 5
+      vertex 3.09017 9.51056 5
+      vertex 5 8.66025 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25434 11.9343 5
+      vertex 3.09017 9.51056 5
+      vertex 3.7082 11.4127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25434 11.9343 5
+      vertex 1.04528 9.94522 5
+      vertex 3.09017 9.51056 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25434 11.9343 5
+      vertex -1.04528 9.94522 5
+      vertex 1.04528 9.94522 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.25434 11.9343 5
+      vertex -1.04528 9.94522 5
+      vertex 1.25434 11.9343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.25434 11.9343 5
+      vertex -3.09017 9.51056 5
+      vertex -1.04528 9.94522 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.7082 11.4127 5
+      vertex -3.09017 9.51056 5
+      vertex -1.25434 11.9343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.7082 11.4127 5
+      vertex -5 8.66025 5
+      vertex -3.09017 9.51056 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6 10.3923 5
+      vertex -5 8.66025 5
+      vertex -3.7082 11.4127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6 10.3923 5
+      vertex -6.69131 7.43145 5
+      vertex -5 8.66025 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.02957 8.91774 5
+      vertex -6.69131 7.43145 5
+      vertex -6 10.3923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.02957 8.91774 5
+      vertex -8.09017 5.87785 5
+      vertex -6.69131 7.43145 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.7082 7.05342 5
+      vertex -8.09017 5.87785 5
+      vertex -8.02957 8.91774 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09017 5.87785 5
+      vertex -9.7082 7.05342 5
+      vertex -9.13545 4.06737 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9625 4.88084 5
+      vertex -9.13545 4.06737 5
+      vertex -9.7082 7.05342 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.13545 4.06737 5
+      vertex -10.9625 4.88084 5
+      vertex -9.78148 2.07912 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7378 2.49494 5
+      vertex -9.78148 2.07912 5
+      vertex -10.9625 4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 0 5
+      vertex 9.78148 -2.07912 5
+      vertex 10 -2 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 -2 5
+      vertex 11.7378 -2.49494 5
+      vertex 11.7898 -2 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7378 -2.49494 5
+      vertex 10 -2 5
+      vertex 10.9625 -4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.13545 -4.06737 5
+      vertex 10 -2 5
+      vertex 9.78148 -2.07912 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 -2 5
+      vertex 9.13545 -4.06737 5
+      vertex 10.9625 -4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.9625 -4.88084 5
+      vertex 9.13545 -4.06737 5
+      vertex 9.7082 -7.05342 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 8.09017 -5.87785 5
+      vertex 9.7082 -7.05342 5
+      vertex 9.13545 -4.06737 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.09017 -5.87785 5
+      vertex 8.02957 -8.91774 5
+      vertex 9.7082 -7.05342 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.69131 -7.43145 5
+      vertex 8.02957 -8.91774 5
+      vertex 8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.69131 -7.43145 5
+      vertex 6 -10.3923 5
+      vertex 8.02957 -8.91774 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5 -8.66025 5
+      vertex 6 -10.3923 5
+      vertex 6.69131 -7.43145 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 -8.66025 5
+      vertex 3.7082 -11.4127 5
+      vertex 6 -10.3923 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.09017 -9.51056 5
+      vertex 3.7082 -11.4127 5
+      vertex 5 -8.66025 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.09017 -9.51056 5
+      vertex 1.25434 -11.9343 5
+      vertex 3.7082 -11.4127 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.04528 -9.94522 5
+      vertex 1.25434 -11.9343 5
+      vertex 3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.04528 -9.94522 5
+      vertex 1.25434 -11.9343 5
+      vertex 1.04528 -9.94522 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.04528 -9.94522 5
+      vertex -1.25434 -11.9343 5
+      vertex 1.25434 -11.9343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.09017 -9.51056 5
+      vertex -1.25434 -11.9343 5
+      vertex -1.04528 -9.94522 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.09017 -9.51056 5
+      vertex -3.7082 -11.4127 5
+      vertex -1.25434 -11.9343 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5 -8.66025 5
+      vertex -3.7082 -11.4127 5
+      vertex -3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5 -8.66025 5
+      vertex -6 -10.3923 5
+      vertex -3.7082 -11.4127 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.69131 -7.43145 5
+      vertex -6 -10.3923 5
+      vertex -5 -8.66025 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.69131 -7.43145 5
+      vertex -8.02957 -8.91774 5
+      vertex -6 -10.3923 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09017 -5.87785 5
+      vertex -8.02957 -8.91774 5
+      vertex -6.69131 -7.43145 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.7082 -7.05342 5
+      vertex -8.09017 -5.87785 5
+      vertex -9.13545 -4.06737 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09017 -5.87785 5
+      vertex -9.7082 -7.05342 5
+      vertex -8.02957 -8.91774 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.9625 -4.88084 5
+      vertex -9.13545 -4.06737 5
+      vertex -9.78148 -2.07912 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7378 -2.49494 5
+      vertex -9.78148 -2.07912 5
+      vertex -10 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.78148 2.07912 5
+      vertex -11.7378 2.49494 5
+      vertex -10 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.13545 -4.06737 5
+      vertex -10.9625 -4.88084 5
+      vertex -9.7082 -7.05342 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 0 5
+      vertex -10 0 5
+      vertex -11.7378 2.49494 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.78148 -2.07912 5
+      vertex -11.7378 -2.49494 5
+      vertex -10.9625 -4.88084 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 0 5
+      vertex -12 0 5
+      vertex -11.7378 -2.49494 5
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 0
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -6 -10.3923 5
+      vertex -8.02957 -8.91774 5
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 -0
+    outer loop
+      vertex -6 -10.3923 5
+      vertex -8.02957 -8.91774 0
+      vertex -6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.25434 11.9343 0
+      vertex -1.25434 11.9343 5
+      vertex 1.25434 11.9343 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.25434 11.9343 5
+      vertex 1.25434 11.9343 0
+      vertex -1.25434 11.9343 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309044 0
+    outer loop
+      vertex -11.7378 2.49494 0
+      vertex -10.9625 4.88084 5
+      vertex -10.9625 4.88084 0
+    endloop
+  endfacet
+  facet normal -0.951048 0.309044 0
+    outer loop
+      vertex -10.9625 4.88084 5
+      vertex -11.7378 2.49494 0
+      vertex -11.7378 2.49494 5
+    endloop
+  endfacet
+  facet normal 0.406745 -0.913542 0
+    outer loop
+      vertex 3.7082 -11.4127 0
+      vertex 6 -10.3923 5
+      vertex 3.7082 -11.4127 5
+    endloop
+  endfacet
+  facet normal 0.406745 -0.913542 0
+    outer loop
+      vertex 6 -10.3923 5
+      vertex 3.7082 -11.4127 0
+      vertex 6 -10.3923 0
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 -0
+    outer loop
+      vertex 8.02957 8.91774 0
+      vertex 6 10.3923 5
+      vertex 8.02957 8.91774 5
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 0
+    outer loop
+      vertex 6 10.3923 5
+      vertex 8.02957 8.91774 0
+      vertex 6 10.3923 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104517 0
+    outer loop
+      vertex -12 0 0
+      vertex -11.7378 2.49494 5
+      vertex -11.7378 2.49494 0
+    endloop
+  endfacet
+  facet normal -0.994523 0.104517 0
+    outer loop
+      vertex -11.7378 2.49494 5
+      vertex -12 0 0
+      vertex -12 0 5
+    endloop
+  endfacet
+  facet normal -0.207918 0.978146 0
+    outer loop
+      vertex -1.25434 11.9343 0
+      vertex -3.7082 11.4127 5
+      vertex -1.25434 11.9343 5
+    endloop
+  endfacet
+  facet normal -0.207918 0.978146 0
+    outer loop
+      vertex -3.7082 11.4127 5
+      vertex -1.25434 11.9343 0
+      vertex -3.7082 11.4127 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669128 0
+    outer loop
+      vertex -8.02957 -8.91774 0
+      vertex -9.7082 -7.05342 5
+      vertex -9.7082 -7.05342 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669128 0
+    outer loop
+      vertex -9.7082 -7.05342 5
+      vertex -8.02957 -8.91774 0
+      vertex -8.02957 -8.91774 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.25434 -11.9343 0
+      vertex 1.25434 -11.9343 5
+      vertex -1.25434 -11.9343 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.25434 -11.9343 5
+      vertex -1.25434 -11.9343 0
+      vertex 1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0.207918 -0.978146 0
+    outer loop
+      vertex -3.7082 -11.4127 0
+      vertex -1.25434 -11.9343 5
+      vertex -3.7082 -11.4127 5
+    endloop
+  endfacet
+  facet normal -0.207918 -0.978146 -0
+    outer loop
+      vertex -1.25434 -11.9343 5
+      vertex -3.7082 -11.4127 0
+      vertex -1.25434 -11.9343 0
+    endloop
+  endfacet
+  facet normal -0.406745 -0.913542 0
+    outer loop
+      vertex -6 -10.3923 0
+      vertex -3.7082 -11.4127 5
+      vertex -6 -10.3923 5
+    endloop
+  endfacet
+  facet normal -0.406745 -0.913542 -0
+    outer loop
+      vertex -3.7082 -11.4127 5
+      vertex -6 -10.3923 0
+      vertex -3.7082 -11.4127 0
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex -6.69131 -7.43145 5
+      vertex -8.09017 -5.87785 0
+      vertex -8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0.743147 0.669129 0
+    outer loop
+      vertex -8.09017 -5.87785 0
+      vertex -6.69131 -7.43145 5
+      vertex -6.69131 -7.43145 0
+    endloop
+  endfacet
+  facet normal -0.951055 -0.309021 0
+    outer loop
+      vertex 9.78148 2.07912 0
+      vertex 9.13545 4.06737 5
+      vertex 9.13545 4.06737 0
+    endloop
+  endfacet
+  facet normal -0.951055 -0.309021 0
+    outer loop
+      vertex 9.13545 4.06737 5
+      vertex 9.78148 2.07912 0
+      vertex 9.78148 2.07912 5
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex 10 0 0
+      vertex 9.78148 2.07912 5
+      vertex 9.78148 2.07912 0
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104526 0
+    outer loop
+      vertex 9.78148 2.07912 5
+      vertex 10 0 0
+      vertex 10 0 5
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex 9.13545 4.06737 0
+      vertex 8.09017 5.87785 5
+      vertex 8.09017 5.87785 0
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex 8.09017 5.87785 5
+      vertex 9.13545 4.06737 0
+      vertex 9.13545 4.06737 5
+    endloop
+  endfacet
+  facet normal -0.951055 0.309021 0
+    outer loop
+      vertex 9.13545 -4.06737 0
+      vertex 9.78148 -2.07912 5
+      vertex 9.78148 -2.07912 0
+    endloop
+  endfacet
+  facet normal -0.951055 0.309021 0
+    outer loop
+      vertex 9.78148 -2.07912 5
+      vertex 9.13545 -4.06737 0
+      vertex 9.13545 -4.06737 5
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex -6.69131 7.43145 0
+      vertex -5 8.66025 5
+      vertex -6.69131 7.43145 5
+    endloop
+  endfacet
+  facet normal 0.587783 -0.809019 0
+    outer loop
+      vertex -5 8.66025 5
+      vertex -6.69131 7.43145 0
+      vertex -5 8.66025 0
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex 6.69131 -7.43145 0
+      vertex 5 -8.66025 5
+      vertex 6.69131 -7.43145 5
+    endloop
+  endfacet
+  facet normal -0.587783 0.809019 0
+    outer loop
+      vertex 5 -8.66025 5
+      vertex 6.69131 -7.43145 0
+      vertex 5 -8.66025 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex 6.69131 -7.43145 0
+      vertex 8.09017 -5.87785 5
+      vertex 8.09017 -5.87785 0
+    endloop
+  endfacet
+  facet normal -0.743147 0.669129 0
+    outer loop
+      vertex 8.09017 -5.87785 5
+      vertex 6.69131 -7.43145 0
+      vertex 6.69131 -7.43145 5
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex 9.78148 -2.07912 0
+      vertex 10 0 5
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal -0.994522 0.104526 0
+    outer loop
+      vertex 10 0 5
+      vertex 9.78148 -2.07912 0
+      vertex 9.78148 -2.07912 5
+    endloop
+  endfacet
+  facet normal 0.406736 0.913546 -0
+    outer loop
+      vertex -3.09017 -9.51056 0
+      vertex -5 -8.66025 5
+      vertex -3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0.406736 0.913546 0
+    outer loop
+      vertex -5 -8.66025 5
+      vertex -3.09017 -9.51056 0
+      vertex -5 -8.66025 0
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 0
+    outer loop
+      vertex 3.09017 9.51056 0
+      vertex 5 8.66025 5
+      vertex 3.09017 9.51056 5
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 -0
+    outer loop
+      vertex 5 8.66025 5
+      vertex 3.09017 9.51056 0
+      vertex 5 8.66025 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex 8.09017 5.87785 0
+      vertex 6.69131 7.43145 5
+      vertex 6.69131 7.43145 0
+    endloop
+  endfacet
+  facet normal -0.743147 -0.669129 0
+    outer loop
+      vertex 6.69131 7.43145 5
+      vertex 8.09017 5.87785 0
+      vertex 8.09017 5.87785 5
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 -0
+    outer loop
+      vertex -5 -8.66025 0
+      vertex -6.69131 -7.43145 5
+      vertex -5 -8.66025 5
+    endloop
+  endfacet
+  facet normal 0.587783 0.809019 0
+    outer loop
+      vertex -6.69131 -7.43145 5
+      vertex -5 -8.66025 0
+      vertex -6.69131 -7.43145 0
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669129 0
+    outer loop
+      vertex -8.09017 5.87785 5
+      vertex -6.69131 7.43145 0
+      vertex -6.69131 7.43145 5
+    endloop
+  endfacet
+  facet normal 0.743147 -0.669129 0
+    outer loop
+      vertex -6.69131 7.43145 0
+      vertex -8.09017 5.87785 5
+      vertex -8.09017 5.87785 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.04528 9.94522 0
+      vertex 1.04528 9.94522 5
+      vertex -1.04528 9.94522 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.04528 9.94522 5
+      vertex -1.04528 9.94522 0
+      vertex 1.04528 9.94522 0
+    endloop
+  endfacet
+  facet normal -0.406736 0.913546 0
+    outer loop
+      vertex 5 -8.66025 0
+      vertex 3.09017 -9.51056 5
+      vertex 5 -8.66025 5
+    endloop
+  endfacet
+  facet normal -0.406736 0.913546 0
+    outer loop
+      vertex 3.09017 -9.51056 5
+      vertex 5 -8.66025 0
+      vertex 3.09017 -9.51056 0
+    endloop
+  endfacet
+  facet normal -0.207914 0.978147 0
+    outer loop
+      vertex 3.09017 -9.51056 0
+      vertex 1.04528 -9.94522 5
+      vertex 3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0.207914 0.978147 0
+    outer loop
+      vertex 1.04528 -9.94522 5
+      vertex 3.09017 -9.51056 0
+      vertex 1.04528 -9.94522 0
+    endloop
+  endfacet
+  facet normal 0.951055 -0.309021 0
+    outer loop
+      vertex -9.78148 2.07912 5
+      vertex -9.13545 4.06737 0
+      vertex -9.13545 4.06737 5
+    endloop
+  endfacet
+  facet normal 0.951055 -0.309021 0
+    outer loop
+      vertex -9.13545 4.06737 0
+      vertex -9.78148 2.07912 5
+      vertex -9.78148 2.07912 0
+    endloop
+  endfacet
+  facet normal 0.951055 0.309021 0
+    outer loop
+      vertex -9.13545 -4.06737 5
+      vertex -9.78148 -2.07912 0
+      vertex -9.78148 -2.07912 5
+    endloop
+  endfacet
+  facet normal 0.951055 0.309021 0
+    outer loop
+      vertex -9.78148 -2.07912 0
+      vertex -9.13545 -4.06737 5
+      vertex -9.13545 -4.06737 0
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex -5 8.66025 0
+      vertex -3.09017 9.51056 5
+      vertex -5 8.66025 5
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex -3.09017 9.51056 5
+      vertex -5 8.66025 0
+      vertex -3.09017 9.51056 0
+    endloop
+  endfacet
+  facet normal 0.207914 0.978147 -0
+    outer loop
+      vertex -1.04528 -9.94522 0
+      vertex -3.09017 -9.51056 5
+      vertex -1.04528 -9.94522 5
+    endloop
+  endfacet
+  facet normal 0.207914 0.978147 0
+    outer loop
+      vertex -3.09017 -9.51056 5
+      vertex -1.04528 -9.94522 0
+      vertex -3.09017 -9.51056 0
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 0
+    outer loop
+      vertex 1.04528 9.94522 0
+      vertex 3.09017 9.51056 5
+      vertex 1.04528 9.94522 5
+    endloop
+  endfacet
+  facet normal -0.207914 -0.978147 -0
+    outer loop
+      vertex 3.09017 9.51056 5
+      vertex 1.04528 9.94522 0
+      vertex 3.09017 9.51056 0
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex -9.78148 -2.07912 5
+      vertex -10 0 0
+      vertex -10 0 5
+    endloop
+  endfacet
+  facet normal 0.994522 0.104526 0
+    outer loop
+      vertex -10 0 0
+      vertex -9.78148 -2.07912 5
+      vertex -9.78148 -2.07912 0
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex -10 0 5
+      vertex -9.78148 2.07912 0
+      vertex -9.78148 2.07912 5
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104526 0
+    outer loop
+      vertex -9.78148 2.07912 0
+      vertex -10 0 5
+      vertex -10 0 0
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -8.09017 -5.87785 5
+      vertex -9.13545 -4.06737 0
+      vertex -9.13545 -4.06737 5
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -9.13545 -4.06737 0
+      vertex -8.09017 -5.87785 5
+      vertex -8.09017 -5.87785 0
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -9.13545 4.06737 5
+      vertex -8.09017 5.87785 0
+      vertex -8.09017 5.87785 5
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -8.09017 5.87785 0
+      vertex -9.13545 4.06737 5
+      vertex -9.13545 4.06737 0
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 8.09017 -5.87785 0
+      vertex 9.13545 -4.06737 5
+      vertex 9.13545 -4.06737 0
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 9.13545 -4.06737 5
+      vertex 8.09017 -5.87785 0
+      vertex 8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 0
+    outer loop
+      vertex 5 8.66025 0
+      vertex 6.69131 7.43145 5
+      vertex 5 8.66025 5
+    endloop
+  endfacet
+  facet normal -0.587783 -0.809019 -0
+    outer loop
+      vertex 6.69131 7.43145 5
+      vertex 5 8.66025 0
+      vertex 6.69131 7.43145 0
+    endloop
+  endfacet
+  facet normal 0.207914 -0.978147 0
+    outer loop
+      vertex -3.09017 9.51056 0
+      vertex -1.04528 9.94522 5
+      vertex -3.09017 9.51056 5
+    endloop
+  endfacet
+  facet normal 0.207914 -0.978147 0
+    outer loop
+      vertex -1.04528 9.94522 5
+      vertex -3.09017 9.51056 0
+      vertex -1.04528 9.94522 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.04528 -9.94522 0
+      vertex -1.04528 -9.94522 5
+      vertex 1.04528 -9.94522 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.04528 -9.94522 5
+      vertex 1.04528 -9.94522 0
+      vertex -1.04528 -9.94522 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10 -2 5
+      vertex 10 0 0
+      vertex 10 0 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 0 0
+      vertex 10 -2 5
+      vertex 10 -2 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10 0 5
+      vertex 10 2 0
+      vertex 10 2 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 2 0
+      vertex 10 0 5
+      vertex 10 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 2 0
+      vertex 11.7898 2 5
+      vertex 10 2 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.7898 2 5
+      vertex 10 2 0
+      vertex 11.7898 2 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.7898 -2 0
+      vertex 10 -2 5
+      vertex 11.7898 -2 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 -2 5
+      vertex 11.7898 -2 0
+      vertex 10 -2 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- add yarn_guide.scad and exported STL
- document yarn guide in machine overview

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ce4272b0832f89f7d50e3b4d1304