### PR TITLE
🎨: align import style with black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,11 +1,6 @@
 import pytest
 
-from wove import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 
 def test_stitches_per_inch():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,13 +1,8 @@
-from .gauge import (
-    rows_per_cm,
-    rows_per_inch,
-    stitches_per_cm,
-    stitches_per_inch,
-)
+from .gauge import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
 
 __all__ = [
-    "stitches_per_inch",
+    "rows_per_cm",
     "rows_per_inch",
     "stitches_per_cm",
-    "rows_per_cm",
+    "stitches_per_inch",
 ]


### PR DESCRIPTION
what: configure isort to match black and tidy imports
why: lint-format job flagged unsorted imports
how to test: pre-commit run --all-files && pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896cbfd1d04832fab47b24b3d7b66ec