### PR TITLE
🧱 : parameterize calibration cube

### DIFF
--- a/cad/calibration_cube.scad
+++ b/cad/calibration_cube.scad
@@ -1,2 +1,7 @@
-// Calibration cube: 20 mm test block for printer calibration
-cube([20, 20, 20]);
+// Calibration cube: customizable test block for printer calibration
+// size: edge length of cube in millimeters
+module calibration_cube(size=20) {
+    cube([size, size, size]);
+}
+
+calibration_cube();

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -8,7 +8,7 @@ The long-term goal of this project is to develop a DIY robotic system that autom
 - **Carriage** – moves the working yarn and needles and includes a center hole for mounting hardware.
 - **Spacer** – maintains consistent gaps between components and now includes an
   optional chamfer for smoother stacking.
-- **Calibration cube** – simple 20 mm block for printer calibration.
+- **Calibration cube** – customizable test block for printer calibration (20 mm by default).
 - **Yarn guide** – directs yarn through the system and helps maintain tension.
 
 Generated G-code or custom instructions will drive these parts to knit automatically.


### PR DESCRIPTION
## Summary
- add configurable size parameter to calibration cube
- document cube as customizable test block

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ec5cd0c8832f9360e5bf832630bc