### PR TITLE
🧵: add gauge helpers for stitch and row counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key features include:
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
 - Utility functions such as stitch and row gauge calculators for inches and centimeters.
+  plus helpers to derive stitch and row counts for a given measurement.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -16,8 +16,12 @@ Continue experimenting with gauge and patterns as you grow more comfortable.
 
 ```python
 from wove import (
+    rows_for_cm,
+    rows_for_inches,
     rows_per_cm,
     rows_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
     stitches_per_cm,
     stitches_per_inch,
 )
@@ -26,6 +30,10 @@ stitches_per_inch(20, 4)  # 5.0 stitches per inch
 rows_per_inch(30, 4)  # 7.5 rows per inch
 stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
+stitches_for_inches(4, 5)  # 20 stitches for 4" width at 5 spi
+rows_for_inches(4, 7.5)  # 30 rows for 4" height at 7.5 rpi
+stitches_for_cm(10, 2)  # 20 stitches for 10 cm width at 2 spc
+rows_for_cm(10, 3)  # 30 rows for 10 cm height at 3 rpc
 ```
 
 All gauge helpers require positive stitch and row counts and positive measurements.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,6 +1,18 @@
+"""Gauge helper tests."""
+
+# isort: skip_file
 import pytest
 
-from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
+from wove import (
+    rows_for_cm,
+    rows_for_inches,
+    rows_per_cm,
+    rows_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
+    stitches_per_cm,
+    stitches_per_inch,
+)
 
 
 def test_stitches_per_inch():
@@ -57,3 +69,39 @@ def test_rows_per_cm_invalid_cm():
 def test_rows_per_cm_invalid_rows():
     with pytest.raises(ValueError):
         rows_per_cm(0, 10)
+
+
+def test_stitches_for_inches():
+    assert stitches_for_inches(4, 5) == 20
+
+
+def test_stitches_for_inches_invalid():
+    with pytest.raises(ValueError):
+        stitches_for_inches(0, 5)
+
+
+def test_rows_for_inches():
+    assert rows_for_inches(4, 7.5) == 30
+
+
+def test_rows_for_inches_invalid():
+    with pytest.raises(ValueError):
+        rows_for_inches(4, 0)
+
+
+def test_stitches_for_cm():
+    assert stitches_for_cm(10, 2) == 20
+
+
+def test_stitches_for_cm_invalid():
+    with pytest.raises(ValueError):
+        stitches_for_cm(10, 0)
+
+
+def test_rows_for_cm():
+    assert rows_for_cm(10, 3) == 30
+
+
+def test_rows_for_cm_invalid():
+    with pytest.raises(ValueError):
+        rows_for_cm(0, 3)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -2,8 +2,12 @@
 from .gauge import (
     rows_per_cm,
     rows_per_inch,
+    rows_for_cm,
+    rows_for_inches,
     stitches_per_cm,
     stitches_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
 )
 
 __all__ = [
@@ -11,4 +15,8 @@ __all__ = [
     "rows_per_inch",
     "stitches_per_cm",
     "rows_per_cm",
+    "stitches_for_inches",
+    "rows_for_inches",
+    "stitches_for_cm",
+    "rows_for_cm",
 ]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -79,3 +79,83 @@ def rows_per_cm(rows: int, cm: float) -> float:
     if cm <= 0:
         raise ValueError("cm must be positive")
     return rows / cm
+
+
+def stitches_for_inches(inches: float, gauge: float) -> int:
+    """Return stitch count for a desired width in inches.
+
+    Args:
+        inches: Desired width in inches. Must be > 0.
+        gauge: Stitch gauge in stitches per inch. Must be > 0.
+
+    Returns:
+        Number of stitches rounded to the nearest integer.
+
+    Raises:
+        ValueError: If ``inches`` or ``gauge`` is not positive.
+    """
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return round(inches * gauge)
+
+
+def rows_for_inches(inches: float, gauge: float) -> int:
+    """Return row count for a desired height in inches.
+
+    Args:
+        inches: Desired height in inches. Must be > 0.
+        gauge: Row gauge in rows per inch. Must be > 0.
+
+    Returns:
+        Number of rows rounded to the nearest integer.
+
+    Raises:
+        ValueError: If ``inches`` or ``gauge`` is not positive.
+    """
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return round(inches * gauge)
+
+
+def stitches_for_cm(cm: float, gauge: float) -> int:
+    """Return stitch count for a desired width in centimeters.
+
+    Args:
+        cm: Desired width in centimeters. Must be > 0.
+        gauge: Stitch gauge in stitches per centimeter. Must be > 0.
+
+    Returns:
+        Number of stitches rounded to the nearest integer.
+
+    Raises:
+        ValueError: If ``cm`` or ``gauge`` is not positive.
+    """
+    if cm <= 0:
+        raise ValueError("cm must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return round(cm * gauge)
+
+
+def rows_for_cm(cm: float, gauge: float) -> int:
+    """Return row count for a desired height in centimeters.
+
+    Args:
+        cm: Desired height in centimeters. Must be > 0.
+        gauge: Row gauge in rows per centimeter. Must be > 0.
+
+    Returns:
+        Number of rows rounded to the nearest integer.
+
+    Raises:
+        ValueError: If ``cm`` or ``gauge`` is not positive.
+    """
+    if cm <= 0:
+        raise ValueError("cm must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return round(cm * gauge)


### PR DESCRIPTION
## Summary
- add functions to compute stitches and rows from gauge
- document new helpers in knitting basics and README

## Testing
- `pre-commit run --all-files`
- `pytest`
- `./scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896ec68c71c832fb952db58ce13b995