### PR TITLE
📝 : allow 'chamfer' in dictionary

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -116,3 +116,4 @@ crochet
 crocheting
 amigurumi
 slipknot
+chamfer


### PR DESCRIPTION
what: add 'chamfer' to spelling allowlist.
why: fix failing pyspelling check for robotic-knitting-machine doc.
how to test: pre-commit run --all-files && pytest.


------
https://chatgpt.com/codex/tasks/task_e_68970e1012a8832f86f260e3f78c8e1e