### PR TITLE
🔧 : add center hole to calibration cube

### DIFF
--- a/cad/calibration_cube.scad
+++ b/cad/calibration_cube.scad
@@ -1,2 +1,9 @@
-// Calibration cube: 20 mm test block for printer calibration
-cube([20, 20, 20]);
+// Calibration cube: 20 mm test block with optional center hole
+module calibration_cube(size=20, hole_diameter=5) {
+    difference() {
+        cube([size, size, size], center=true);
+        cylinder(h=size + 2, d=hole_diameter, center=true);
+    }
+}
+
+calibration_cube();

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -8,7 +8,8 @@ The long-term goal of this project is to develop a DIY robotic system that autom
 - **Carriage** – moves the working yarn and needles and includes a center hole for mounting hardware.
 - **Spacer** – maintains consistent gaps between components and now includes an
   optional chamfer for smoother stacking.
-- **Calibration cube** – simple 20 mm block for printer calibration.
+- **Calibration cube** – simple 20 mm block with a center hole for printer
+  calibration and bridging tests.
 - **Yarn guide** – directs yarn through the system and helps maintain tension.
 - **End cap** – covers rod ends to prevent snagging.
 

--- a/stl/calibration_cube.stl
+++ b/stl/calibration_cube.stl
@@ -1,86 +1,338 @@
 solid OpenSCAD_Model
-  facet normal -0 0 1
-    outer loop
-      vertex 0 20 20
-      vertex 20 0 20
-      vertex 20 20 20
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20 0 20
-      vertex 0 20 20
-      vertex 0 0 20
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 0 0
-      vertex 20 20 0
-      vertex 20 0 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 20 20 0
-      vertex 0 0 0
-      vertex 0 20 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0 0 0
-      vertex 20 0 20
-      vertex 0 0 20
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 20 0 20
-      vertex 0 0 0
-      vertex 20 0 0
-    endloop
-  endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 20 0 20
-      vertex 20 20 0
-      vertex 20 20 20
+      vertex 10 -10 10
+      vertex 10 10 -10
+      vertex 10 10 10
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 20 20 0
-      vertex 20 0 20
-      vertex 20 0 0
+      vertex 10 10 -10
+      vertex 10 -10 10
+      vertex 10 -10 -10
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0 0 1
     outer loop
-      vertex 20 20 0
-      vertex 0 20 20
-      vertex 20 20 20
+      vertex 10 10 10
+      vertex 2.5 0 10
+      vertex 10 -10 10
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 0 1
     outer loop
-      vertex 0 20 20
-      vertex 20 20 0
-      vertex 0 20 0
+      vertex 10 10 10
+      vertex 1.76777 1.76777 10
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 10
+      vertex 0 2.5 10
+      vertex 1.76777 1.76777 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10 10 10
+      vertex 0 2.5 10
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.76777 1.76777 10
+      vertex -10 10 10
+      vertex -2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 2.5 10
+      vertex -10 10 10
+      vertex -1.76777 1.76777 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.76777 -1.76777 10
+      vertex 10 -10 10
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -2.5 10
+      vertex 10 -10 10
+      vertex 1.76777 -1.76777 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -10 10
+      vertex 0 -2.5 10
+      vertex -1.76777 -1.76777 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 -10 10
+      vertex -2.5 0 10
+      vertex -10 10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -2.5 10
+      vertex -10 -10 10
+      vertex 10 -10 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 0 10
+      vertex -10 -10 10
+      vertex -1.76777 -1.76777 10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -10 -10
+      vertex 2.5 0 -10
+      vertex 10 10 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -10 -10
+      vertex 1.76777 -1.76777 -10
+      vertex 2.5 0 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 -10 -10
+      vertex 0 -2.5 -10
+      vertex 1.76777 -1.76777 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 -10 -10
+      vertex 0 -2.5 -10
+      vertex 10 -10 -10
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.76777 -1.76777 -10
+      vertex -10 -10 -10
+      vertex -2.5 0 -10
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0 -2.5 -10
+      vertex -10 -10 -10
+      vertex -1.76777 -1.76777 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.76777 1.76777 -10
+      vertex 10 10 -10
+      vertex 2.5 0 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 2.5 -10
+      vertex 10 10 -10
+      vertex 1.76777 1.76777 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 10 -10
+      vertex 0 2.5 -10
+      vertex -1.76777 1.76777 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 10 -10
+      vertex -2.5 0 -10
+      vertex -10 -10 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 2.5 -10
+      vertex -10 10 -10
+      vertex 10 10 -10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.5 0 -10
+      vertex -10 10 -10
+      vertex -1.76777 1.76777 -10
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0 0 0
-      vertex 0 20 20
-      vertex 0 20 0
+      vertex -10 -10 -10
+      vertex -10 10 10
+      vertex -10 10 -10
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 0 20 20
-      vertex 0 0 0
-      vertex 0 0 20
+      vertex -10 10 10
+      vertex -10 -10 -10
+      vertex -10 -10 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10 10 -10
+      vertex -10 10 10
+      vertex 10 10 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10 10 10
+      vertex 10 10 -10
+      vertex -10 10 -10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -10 -10 -10
+      vertex 10 -10 10
+      vertex -10 -10 10
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 10 -10 10
+      vertex -10 -10 -10
+      vertex 10 -10 -10
+    endloop
+  endfacet
+  facet normal 0.92388 0.382682 0
+    outer loop
+      vertex -1.76777 -1.76777 10
+      vertex -2.5 0 -10
+      vertex -2.5 0 10
+    endloop
+  endfacet
+  facet normal 0.92388 0.382682 0
+    outer loop
+      vertex -2.5 0 -10
+      vertex -1.76777 -1.76777 10
+      vertex -1.76777 -1.76777 -10
+    endloop
+  endfacet
+  facet normal -0.382682 -0.92388 0
+    outer loop
+      vertex 0 2.5 -10
+      vertex 1.76777 1.76777 10
+      vertex 0 2.5 10
+    endloop
+  endfacet
+  facet normal -0.382682 -0.92388 -0
+    outer loop
+      vertex 1.76777 1.76777 10
+      vertex 0 2.5 -10
+      vertex 1.76777 1.76777 -10
+    endloop
+  endfacet
+  facet normal -0.92388 -0.382682 0
+    outer loop
+      vertex 2.5 0 -10
+      vertex 1.76777 1.76777 10
+      vertex 1.76777 1.76777 -10
+    endloop
+  endfacet
+  facet normal -0.92388 -0.382682 0
+    outer loop
+      vertex 1.76777 1.76777 10
+      vertex 2.5 0 -10
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal 0.382682 0.92388 -0
+    outer loop
+      vertex 0 -2.5 -10
+      vertex -1.76777 -1.76777 10
+      vertex 0 -2.5 10
+    endloop
+  endfacet
+  facet normal 0.382682 0.92388 0
+    outer loop
+      vertex -1.76777 -1.76777 10
+      vertex 0 -2.5 -10
+      vertex -1.76777 -1.76777 -10
+    endloop
+  endfacet
+  facet normal 0.92388 -0.382682 0
+    outer loop
+      vertex -2.5 0 10
+      vertex -1.76777 1.76777 -10
+      vertex -1.76777 1.76777 10
+    endloop
+  endfacet
+  facet normal 0.92388 -0.382682 0
+    outer loop
+      vertex -1.76777 1.76777 -10
+      vertex -2.5 0 10
+      vertex -2.5 0 -10
+    endloop
+  endfacet
+  facet normal 0.382682 -0.92388 0
+    outer loop
+      vertex -1.76777 1.76777 -10
+      vertex 0 2.5 10
+      vertex -1.76777 1.76777 10
+    endloop
+  endfacet
+  facet normal 0.382682 -0.92388 0
+    outer loop
+      vertex 0 2.5 10
+      vertex -1.76777 1.76777 -10
+      vertex 0 2.5 -10
+    endloop
+  endfacet
+  facet normal -0.92388 0.382682 0
+    outer loop
+      vertex 1.76777 -1.76777 -10
+      vertex 2.5 0 10
+      vertex 2.5 0 -10
+    endloop
+  endfacet
+  facet normal -0.92388 0.382682 0
+    outer loop
+      vertex 2.5 0 10
+      vertex 1.76777 -1.76777 -10
+      vertex 1.76777 -1.76777 10
+    endloop
+  endfacet
+  facet normal -0.382682 0.92388 0
+    outer loop
+      vertex 1.76777 -1.76777 -10
+      vertex 0 -2.5 10
+      vertex 1.76777 -1.76777 10
+    endloop
+  endfacet
+  facet normal -0.382682 0.92388 0
+    outer loop
+      vertex 0 -2.5 10
+      vertex 1.76777 -1.76777 -10
+      vertex 0 -2.5 -10
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- add parametric calibration cube with optional center hole
- regenerate corresponding STL and update docs

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689918a4d61c832f9c89ba2639771c54