### PR TITLE
⚙️ add clearance option to needle adapter

### DIFF
--- a/cad/needle_adapter.scad
+++ b/cad/needle_adapter.scad
@@ -1,8 +1,9 @@
 // Adapter for holding a knitting needle
-module needle_adapter(needle_diameter=3, length=40) {
+// clearance: extra space added to the needle diameter for easier insertion
+module needle_adapter(needle_diameter=3, length=40, clearance=0.2) {
     difference() {
         cylinder(d=needle_diameter + 2, h=length);
-        cylinder(d=needle_diameter, h=length);
+        cylinder(d=needle_diameter + clearance, h=length);
     }
 }
 

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -3,7 +3,8 @@
 The long-term goal of this project is to develop a DIY robotic system that automates knitting. Components are modeled in OpenSCAD and live in the `cad/` directory.
 
 ## Planned Modules
-- **Needle adapter** – holds a standard needle and connects to a stepper-driven carriage.
+- **Needle adapter** – holds a standard needle with adjustable clearance and connects to a
+  stepper-driven carriage.
 - **Stepper mount** – secures a motor for precise control.
 - **Carriage** – moves the working yarn and needles and includes a center hole for mounting hardware.
 - **Spacer** – maintains consistent gaps between components and now includes an

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Render a single OpenSCAD file to STL.
+# Usage: scripts/openscad_render.sh path/to/file.scad
+# Set STANDOFF_MODE=printed for alternate mode.
+
+set -euo pipefail
+
+mode="${STANDOFF_MODE:-heatset}"
+scad="$1"
+out_dir="stl"
+base="$(basename "$scad" .scad)"
+out="$out_dir/${base}_${mode}.stl"
+
+mkdir -p "$out_dir"
+echo "[INFO] Rendering $scad in $mode mode -> $out"
+openscad -o "$out" -D STANDOFF_MODE=\"$mode\" "$scad"


### PR DESCRIPTION
## Summary
- add clearance param to needle adapter
- document adjustable needle adapter
- add openscad_render.sh helper

## Testing
- `bash scripts/openscad_render.sh cad/needle_adapter.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/needle_adapter.scad`
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689918dbfc08832fa43a4885de7a3c1a