### PR TITLE
🧱 : parameterize calibration cube

### DIFF
--- a/cad/calibration_cube.scad
+++ b/cad/calibration_cube.scad
@@ -1,2 +1,6 @@
-// Calibration cube: 20 mm test block for printer calibration
-cube([20, 20, 20]);
+// Calibration cube: parametric test block for printer calibration
+module calibration_cube(size=20) {
+    cube([size, size, size]);
+}
+
+calibration_cube();

--- a/docs/calibration_cube.md
+++ b/docs/calibration_cube.md
@@ -1,0 +1,10 @@
+# Calibration Cube
+
+The `cad/calibration_cube.scad` module generates a parametric calibration block for 3D printer tuning.
+Adjust the `size` parameter to change the cube's edge length (default 20 mm):
+
+```scad
+calibration_cube(size=25);
+```
+
+Use the OpenSCAD render script to export STL files for both heatset and printed standoff modes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 knitting-basics
 crochet-basics
 robotic-knitting-machine
+calibration_cube
 styleguides/python
 prompts-codex
 prompts-codex-cad


### PR DESCRIPTION
## What
- allow calibration cube size customization
- document calibration cube usage

## Why
- enables printing calibration blocks of varying dimensions

## How to test
- bash scripts/build_stl.sh
- STANDOFF_MODE=printed bash scripts/build_stl.sh
- pre-commit run --all-files
- pytest


------
https://chatgpt.com/codex/tasks/task_e_689918dbfc08832fa43a4885de7a3c1a