### PR TITLE
Add gauge conversion helpers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.py]
+indent_size = 4

--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -12,5 +12,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 isort black
           flake8 . --exclude=.venv
-          isort --check-only . --skip .venv
+          isort --profile black --check-only . --skip .venv
           black --check . --exclude ".venv/"

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -16,6 +16,8 @@ Continue experimenting with gauge and patterns as you grow more comfortable.
 
 ```python
 from wove import (
+    per_cm_to_per_inch,
+    per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
     stitches_per_cm,
@@ -26,6 +28,8 @@ stitches_per_inch(20, 4)  # 5.0 stitches per inch
 rows_per_inch(30, 4)  # 7.5 rows per inch
 stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
+per_inch_to_per_cm(5.08)  # ~2.0 per cm
+per_cm_to_per_inch(2.0)  # ~5.08 per inch
 ```
 
 All gauge helpers require positive stitch and row counts and positive measurements.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,6 +1,13 @@
 import pytest
 
-from wove import rows_per_cm, rows_per_inch, stitches_per_cm, stitches_per_inch
+from wove import (
+    per_cm_to_per_inch,
+    per_inch_to_per_cm,
+    rows_per_cm,
+    rows_per_inch,
+    stitches_per_cm,
+    stitches_per_inch,
+)
 
 
 def test_stitches_per_inch():
@@ -57,3 +64,21 @@ def test_rows_per_cm_invalid_cm():
 def test_rows_per_cm_invalid_rows():
     with pytest.raises(ValueError):
         rows_per_cm(0, 10)
+
+
+def test_per_inch_to_per_cm():
+    assert per_inch_to_per_cm(5.08) == pytest.approx(2.0)
+
+
+def test_per_inch_to_per_cm_invalid():
+    with pytest.raises(ValueError):
+        per_inch_to_per_cm(0)
+
+
+def test_per_cm_to_per_inch():
+    assert per_cm_to_per_inch(2.0) == pytest.approx(5.08)
+
+
+def test_per_cm_to_per_inch_invalid():
+    with pytest.raises(ValueError):
+        per_cm_to_per_inch(0)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,5 +1,7 @@
 # isort: skip_file
 from .gauge import (
+    per_cm_to_per_inch,
+    per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
     stitches_per_cm,
@@ -11,4 +13,6 @@ __all__ = [
     "rows_per_inch",
     "stitches_per_cm",
     "rows_per_cm",
+    "per_inch_to_per_cm",
+    "per_cm_to_per_inch",
 ]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+CM_PER_INCH = 2.54
+
 
 def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
@@ -79,3 +81,37 @@ def rows_per_cm(rows: int, cm: float) -> float:
     if cm <= 0:
         raise ValueError("cm must be positive")
     return rows / cm
+
+
+def per_inch_to_per_cm(value: float) -> float:
+    """Convert a gauge measured per inch to per centimeter.
+
+    Args:
+        value: Gauge value per inch. Must be > 0.
+
+    Returns:
+        Gauge value per centimeter.
+
+    Raises:
+        ValueError: If ``value`` is not positive.
+    """
+    if value <= 0:
+        raise ValueError("value must be positive")
+    return value / CM_PER_INCH
+
+
+def per_cm_to_per_inch(value: float) -> float:
+    """Convert a gauge measured per centimeter to per inch.
+
+    Args:
+        value: Gauge value per centimeter. Must be > 0.
+
+    Returns:
+        Gauge value per inch.
+
+    Raises:
+        ValueError: If ``value`` is not positive.
+    """
+    if value <= 0:
+        raise ValueError("value must be positive")
+    return value * CM_PER_INCH


### PR DESCRIPTION
## Summary
- expose per_inch_to_per_cm and per_cm_to_per_inch gauge helpers
- document conversion examples in knitting guide

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm run lint` (fails: Could not read package.json)
- `npm run test:ci` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689918d0fca4832fb5f3cf92c57fa343