### PR TITLE
🧪 : expand gauge validation tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters.
+- Utility functions like stitch/row gauge calculators for inches and centimeters, with input checks.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -7,53 +7,61 @@ def test_stitches_per_inch():
     assert stitches_per_inch(20, 4) == 5.0
 
 
-def test_stitches_per_inch_invalid_inches():
+@pytest.mark.parametrize("bad_inches", [0, -4])
+def test_stitches_per_inch_invalid_inches(bad_inches: float) -> None:
     with pytest.raises(ValueError):
-        stitches_per_inch(10, 0)
+        stitches_per_inch(10, bad_inches)
 
 
-def test_stitches_per_inch_invalid_stitches():
+@pytest.mark.parametrize("bad_stitches", [0, -10])
+def test_stitches_per_inch_invalid_stitches(bad_stitches: int) -> None:
     with pytest.raises(ValueError):
-        stitches_per_inch(0, 4)
+        stitches_per_inch(bad_stitches, 4)
 
 
 def test_rows_per_inch():
     assert rows_per_inch(30, 4) == 7.5
 
 
-def test_rows_per_inch_invalid_inches():
+@pytest.mark.parametrize("bad_inches", [0, -4])
+def test_rows_per_inch_invalid_inches(bad_inches: float) -> None:
     with pytest.raises(ValueError):
-        rows_per_inch(10, 0)
+        rows_per_inch(10, bad_inches)
 
 
-def test_rows_per_inch_invalid_rows():
+@pytest.mark.parametrize("bad_rows", [0, -10])
+def test_rows_per_inch_invalid_rows(bad_rows: int) -> None:
     with pytest.raises(ValueError):
-        rows_per_inch(0, 4)
+        rows_per_inch(bad_rows, 4)
 
 
 def test_stitches_per_cm():
     assert stitches_per_cm(20, 10) == 2.0
 
 
-def test_stitches_per_cm_invalid_cm():
+@pytest.mark.parametrize("bad_cm", [0, -10])
+def test_stitches_per_cm_invalid_cm(bad_cm: float) -> None:
     with pytest.raises(ValueError):
-        stitches_per_cm(10, 0)
+        stitches_per_cm(10, bad_cm)
 
 
-def test_stitches_per_cm_invalid_stitches():
+@pytest.mark.parametrize("bad_stitches", [0, -10])
+def test_stitches_per_cm_invalid_stitches(bad_stitches: int) -> None:
     with pytest.raises(ValueError):
-        stitches_per_cm(0, 10)
+        stitches_per_cm(bad_stitches, 10)
 
 
 def test_rows_per_cm():
     assert rows_per_cm(30, 10) == 3.0
 
 
-def test_rows_per_cm_invalid_cm():
+@pytest.mark.parametrize("bad_cm", [0, -10])
+def test_rows_per_cm_invalid_cm(bad_cm: float) -> None:
     with pytest.raises(ValueError):
-        rows_per_cm(10, 0)
+        rows_per_cm(10, bad_cm)
 
 
-def test_rows_per_cm_invalid_rows():
+@pytest.mark.parametrize("bad_rows", [0, -10])
+def test_rows_per_cm_invalid_rows(bad_rows: int) -> None:
     with pytest.raises(ValueError):
-        rows_per_cm(0, 10)
+        rows_per_cm(bad_rows, 10)


### PR DESCRIPTION
## Summary
- cover negative inputs in gauge helpers with pytest parametrization
- document input checks for gauge utilities

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689918d0fca4832fb5f3cf92c57fa343