### PR TITLE
Add inch/cm conversion helpers

### DIFF
--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -16,6 +16,8 @@ Continue experimenting with gauge and patterns as you grow more comfortable.
 
 ```python
 from wove import (
+    cm_to_inches,
+    inches_to_cm,
     rows_per_cm,
     rows_per_inch,
     stitches_per_cm,
@@ -26,6 +28,8 @@ stitches_per_inch(20, 4)  # 5.0 stitches per inch
 rows_per_inch(30, 4)  # 7.5 rows per inch
 stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
+inches_to_cm(2)  # 5.08 cm
+cm_to_inches(10)  # 3.93700787 inches
 ```
 
 All gauge helpers require positive stitch and row counts and positive measurements.

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,21 @@
+import pytest
+
+from wove import cm_to_inches, inches_to_cm
+
+
+def test_inches_to_cm():
+    assert inches_to_cm(2) == pytest.approx(5.08)
+
+
+def test_inches_to_cm_invalid():
+    with pytest.raises(ValueError):
+        inches_to_cm(0)
+
+
+def test_cm_to_inches():
+    assert cm_to_inches(10) == pytest.approx(3.93700787, rel=1e-6)
+
+
+def test_cm_to_inches_invalid():
+    with pytest.raises(ValueError):
+        cm_to_inches(0)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,7 +1,9 @@
 # isort: skip_file
 from .gauge import (
+    cm_to_inches,
     rows_per_cm,
     rows_per_inch,
+    inches_to_cm,
     stitches_per_cm,
     stitches_per_inch,
 )
@@ -11,4 +13,6 @@ __all__ = [
     "rows_per_inch",
     "stitches_per_cm",
     "rows_per_cm",
+    "inches_to_cm",
+    "cm_to_inches",
 ]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+CM_PER_INCH = 2.54
+
 
 def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
@@ -79,3 +81,17 @@ def rows_per_cm(rows: int, cm: float) -> float:
     if cm <= 0:
         raise ValueError("cm must be positive")
     return rows / cm
+
+
+def inches_to_cm(inches: float) -> float:
+    """Return length in centimeters for a positive inch value."""
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    return inches * CM_PER_INCH
+
+
+def cm_to_inches(cm: float) -> float:
+    """Return length in inches for a positive centimeter value."""
+    if cm <= 0:
+        raise ValueError("cm must be positive")
+    return cm / CM_PER_INCH


### PR DESCRIPTION
## Summary
- add helpers to convert between inches and centimeters
- document unit conversion usage
- test conversion utilities

## Testing
- `pre-commit run --all-files`
- `pytest`
- `./scripts/checks.sh` *(fails: No such file or directory: 'aspell')*

------
https://chatgpt.com/codex/tasks/task_e_689918d0fca4832fb5f3cf92c57fa343