### PR TITLE
📝 docs: mention spell and link checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ pre-commit install
 # run checks
 pre-commit run --all-files
 pytest
+
+# for documentation changes
+pyspelling -c .spellcheck.yaml  # requires 'aspell'
+linkchecker README.md docs/
 ```
 
 The [`scripts/checks.sh`](scripts/checks.sh) script runs:

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -117,3 +117,7 @@ crocheting
 amigurumi
 slipknot
 chamfer
+aspell
+linkchecker
+pyspelling
+yaml


### PR DESCRIPTION
## Summary
- document pyspelling and linkchecker commands for docs changes
- allow spellcheck dictionary to include tooling terms

## Testing
- `pre-commit run --all-files`
- `pytest`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689abba3f6a0832fa99fe1c7475704a2