### PR TITLE
Add chamfer option to washer model

### DIFF
--- a/cad/washer.scad
+++ b/cad/washer.scad
@@ -2,10 +2,21 @@
 // outer_diameter: overall diameter
 // inner_diameter: hole diameter
 // thickness: washer height
-module washer(outer_diameter=20, inner_diameter=10, thickness=2) {
+// chamfer: size of edge bevel; ensure thickness >= 2*chamfer
+module washer(outer_diameter=20, inner_diameter=10, thickness=2, chamfer=0) {
     difference() {
-        // outer disc
-        cylinder(d=outer_diameter, h=thickness);
+        union() {
+            // main body
+            translate([0, 0, chamfer])
+                cylinder(d=outer_diameter - 2 * chamfer, h=thickness - 2 * chamfer);
+            if (chamfer > 0) {
+                // bottom chamfer
+                cylinder(d1=outer_diameter - 2 * chamfer, d2=outer_diameter, h=chamfer);
+                // top chamfer
+                translate([0, 0, thickness - chamfer])
+                    cylinder(d1=outer_diameter, d2=outer_diameter - 2 * chamfer, h=chamfer);
+            }
+        }
         // inner hole
         cylinder(d=inner_diameter, h=thickness);
     }

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -11,7 +11,7 @@ The long-term goal of this project is to develop a DIY robotic system that autom
   optional chamfer for smoother stacking.
 - **Calibration cube** – simple 20 mm block with a center hole for printer
   calibration and bridging tests.
-- **Washer** – flat ring for spacing hardware components.
+- **Washer** – flat ring for spacing hardware components with an optional chamfer for smoother edges.
 - **Yarn guide** – directs yarn through the system and helps maintain tension.
 - **End cap** – covers rod ends to prevent snagging and now includes an optional
   chamfer for smoother edges.


### PR DESCRIPTION
## Summary
- allow optional chamfer on washer module
- document chamfered washer in robotic knitting machine overview

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689abb958b7c832faf7256974c1cf436