### PR TITLE
Add centimeter-inch conversion helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters.
+- Utility functions such as stitch and row gauge calculators for inches and centimeters,
+  plus simple unit conversion helpers.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/knitting-basics.md
+++ b/docs/knitting-basics.md
@@ -16,6 +16,8 @@ Continue experimenting with gauge and patterns as you grow more comfortable.
 
 ```python
 from wove import (
+    cm_to_inches,
+    inches_to_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
     rows_per_cm,
@@ -30,7 +32,10 @@ stitches_per_cm(20, 10)  # 2.0 stitches per cm
 rows_per_cm(30, 10)  # 3.0 rows per cm
 per_inch_to_per_cm(5.08)  # ~2.0 per cm
 per_cm_to_per_inch(2.0)  # ~5.08 per inch
+inches_to_cm(1)  # 2.54 cm
+cm_to_inches(2.54)  # 1.0 in
 ```
 
 All gauge helpers require positive stitch and row counts and positive measurements.
-Passing non-positive values raises ``ValueError``.
+Passing non-positive values raises ``ValueError``. Unit conversion helpers accept
+non-negative values and raise ``ValueError`` for negatives.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,6 +1,8 @@
 import pytest
 
 from wove import (
+    cm_to_inches,
+    inches_to_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
     rows_per_cm,
@@ -82,3 +84,21 @@ def test_per_cm_to_per_inch():
 def test_per_cm_to_per_inch_invalid():
     with pytest.raises(ValueError):
         per_cm_to_per_inch(0)
+
+
+def test_inches_to_cm():
+    assert inches_to_cm(1.0) == pytest.approx(2.54)
+
+
+def test_inches_to_cm_invalid():
+    with pytest.raises(ValueError):
+        inches_to_cm(-1)
+
+
+def test_cm_to_inches():
+    assert cm_to_inches(2.54) == pytest.approx(1.0)
+
+
+def test_cm_to_inches_invalid():
+    with pytest.raises(ValueError):
+        cm_to_inches(-1)

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,5 +1,7 @@
 # isort: skip_file
 from .gauge import (
+    cm_to_inches,
+    inches_to_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
     rows_per_cm,
@@ -9,6 +11,8 @@ from .gauge import (
 )
 
 __all__ = [
+    "cm_to_inches",
+    "inches_to_cm",
     "stitches_per_inch",
     "rows_per_inch",
     "stitches_per_cm",

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -3,6 +3,42 @@ from __future__ import annotations
 CM_PER_INCH = 2.54
 
 
+def inches_to_cm(inches: float) -> float:
+    """Convert inches to centimeters.
+
+    Args:
+        inches: Length in inches. Must be \u2265 0.
+
+    Returns:
+        Equivalent length in centimeters.
+
+    Raises:
+        ValueError: If ``inches`` is negative.
+    """
+
+    if inches < 0:
+        raise ValueError("inches must be non-negative")
+    return inches * CM_PER_INCH
+
+
+def cm_to_inches(cm: float) -> float:
+    """Convert centimeters to inches.
+
+    Args:
+        cm: Length in centimeters. Must be \u2265 0.
+
+    Returns:
+        Equivalent length in inches.
+
+    Raises:
+        ValueError: If ``cm`` is negative.
+    """
+
+    if cm < 0:
+        raise ValueError("cm must be non-negative")
+    return cm / CM_PER_INCH
+
+
 def stitches_per_inch(stitches: int, inches: float) -> float:
     """Return stitch gauge in stitches per inch.
 


### PR DESCRIPTION
## Summary
- add inches_to_cm and cm_to_inches helpers
- cover conversions with tests and docs

## Testing
- `pre-commit run --all-files`
- `pytest`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_689abb8eba90832f92b5a60017d0e5bb