### PR TITLE
📚 add gauge helper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters.
+- Utility functions such as stitch and row gauge calculators for inches and
+  centimeters. See [docs/gauge.md](docs/gauge.md) for examples.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ orphan: true
 - [Knitting Basics](knitting-basics.md)
 - [Crochet Guide](crochet-basics.md)
 - [Robotic Knitting Machine](robotic-knitting-machine.md)
+- [Gauge utilities](gauge.md)
 - [Python Style Guide](styleguides/python.md)
 - [Codex Prompt](prompts-codex.md)
 - [Codex CAD Prompt](prompts-codex-cad.md)

--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -1,0 +1,15 @@
+# Gauge utilities
+
+The `wove.gauge` module provides helpers for calculating stitch and row gauge and
+converting measurements between inches and centimeters.
+
+```python
+from wove import stitches_per_inch, per_cm_to_per_inch
+
+stitches_per_inch(20, 4)  # 5.0
+per_cm_to_per_inch(2.0)  # 5.08
+```
+
+Each function checks that its inputs are positive and raises `ValueError` when
+an invalid value is supplied.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 knitting-basics
 crochet-basics
 robotic-knitting-machine
+gauge
 styleguides/python
 prompts-codex
 prompts-codex-cad


### PR DESCRIPTION
## Summary
- document `wove.gauge` helpers with a new usage guide
- link gauge page from docs and README

## Testing
- `pre-commit run --all-files`
- `pytest`
- `./scripts/checks.sh` *(reports unsorted imports in tests/test_gauge.py)*

------
https://chatgpt.com/codex/tasks/task_e_689abb8eba90832f92b5a60017d0e5bb