### PR TITLE
docs: link CAD directory in robot knitting doc

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -12,4 +12,3 @@ per_cm_to_per_inch(2.0)  # 5.08
 
 Each function checks that its inputs are positive and raises `ValueError` when
 an invalid value is supplied.
-

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -1,6 +1,8 @@
 # Robotic Knitting Machine Overview
 
-The long-term goal of this project is to develop a DIY robotic system that automates knitting. Components are modeled in OpenSCAD and live in the `cad/` directory.
+The long-term goal of this project is to develop a DIY robotic system that automates
+knitting. Components are modeled in [OpenSCAD](https://openscad.org/) and stored in
+the [`cad/`](../cad/) directory, where you can modify or export printable parts.
 
 ## Planned Modules
 - **Needle adapter** – holds a standard needle with adjustable clearance and connects to a


### PR DESCRIPTION
## Summary
- link to OpenSCAD and cad directory in the robotic knitting machine overview
- trim stray newline in gauge utilities doc

## Testing
- `pre-commit run --all-files`
- `pytest`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b02c23c832f90c87413b800c23f