### PR TITLE
🛠️ : – add mode-aware alignment pin and docs

### DIFF
--- a/cad/alignment_pin.scad
+++ b/cad/alignment_pin.scad
@@ -1,8 +1,15 @@
 // Alignment pin for assembly positioning
-// Parameters: diameter and height
+// Parameters: diameter, height, and optional taper
 $fn = 100;
-module alignment_pin(d=5, h=20) {
-    cylinder(d=d, h=h);
+mode = is_undef(STANDOFF_MODE) ? "heatset" : STANDOFF_MODE;
+
+module alignment_pin(d=5, h=20, tip=1) {
+    if (mode == "printed") {
+        cylinder(d = d, h = h);
+    } else {
+        // heatset mode: taper to ease insertion
+        cylinder(h = h, d1 = d, d2 = d - tip);
+    }
 }
 
 alignment_pin();

--- a/docs/alignment_pin.md
+++ b/docs/alignment_pin.md
@@ -1,0 +1,17 @@
+# Alignment pin
+
+Simple cylindrical pin used to align parts during assembly.
+
+The OpenSCAD source `cad/alignment_pin.scad` supports two render modes:
+
+- **heatset** (default): adds a slight taper to aid installation with heat-set inserts.
+- **printed**: renders a straight pin for direct 3D printing.
+
+Render the models with:
+
+```
+bash scripts/openscad_render.sh cad/alignment_pin.scad
+STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/alignment_pin.scad
+```
+
+The STL files are generated in `stl/` but are not committed to the repository.

--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -12,4 +12,3 @@ per_cm_to_per_inch(2.0)  # 5.08
 
 Each function checks that its inputs are positive and raises `ValueError` when
 an invalid value is supplied.
-


### PR DESCRIPTION
## Summary
- handle STANDOFF_MODE in alignment_pin.scad for heatset vs printed
- document alignment pin render modes; normalize gauge doc newline

## Testing
- `bash scripts/openscad_render.sh cad/alignment_pin.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/alignment_pin.scad`
- `pre-commit run --all-files`
- `pytest`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5afe99f8832faf4ec81caced0cf2