### PR TITLE
📝 : remove redundant word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Key features include:
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
 - Utility functions such as stitch and row gauge calculators for inches and centimeters,
-  plus simple unit conversion helpers.centimeters. See [docs/gauge.md](docs/gauge.md)
-  for examples.
+  plus simple unit conversion helpers. See [docs/gauge.md](docs/gauge.md) for examples.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 


### PR DESCRIPTION
## Summary
- remove extra "centimeters" phrase in README for clarity

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb73bc6c0832fa495ced49b4a0d6e