### PR TITLE
Add stitch count helpers for gauge calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Key features include:
 - CI workflows for linting, testing, and docs previews.
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
-- Utility functions such as stitch and row gauge calculators for inches and centimeters,
-  plus simple unit conversion helpers.centimeters. See [docs/gauge.md](docs/gauge.md)
-  for examples.
+- Utility functions such as stitch and row gauge calculators for inches and
+  centimeters, plus simple unit conversion helpers. See
+  [docs/gauge.md](docs/gauge.md) for examples.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -1,7 +1,8 @@
 # Gauge utilities
 
-The `wove.gauge` module provides helpers for calculating stitch and row gauge and
-converting measurements between inches and centimeters.
+The `wove.gauge` module provides helpers for calculating stitch and row gauge,
+converting measurements between inches and centimeters, and estimating the
+number of stitches needed for a given width.
 
 To calculate gauge:
 
@@ -11,14 +12,18 @@ To calculate gauge:
 
 ```python
 from wove import (
-    stitches_per_inch,
-    rows_per_inch,
     per_cm_to_per_inch,
+    rows_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
+    stitches_per_inch,
 )
 
-stitches_per_inch(20, 4)  # 5.0 stitches per inch
-rows_per_inch(30, 4)      # 7.5 rows per inch
-per_cm_to_per_inch(2.0)   # 5.08
+stitches_per_inch(20, 4)     # 5.0 stitches per inch
+rows_per_inch(30, 4)         # 7.5 rows per inch
+per_cm_to_per_inch(2.0)      # 5.08
+stitches_for_inches(5.0, 4)  # 20 stitches
+stitches_for_cm(2.0, 10)     # 20 stitches
 ```
 
 Each function checks that its inputs are positive and raises `ValueError`

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -7,6 +7,8 @@ from wove import (
     per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
     stitches_per_cm,
     stitches_per_inch,
 )
@@ -84,6 +86,34 @@ def test_per_cm_to_per_inch():
 def test_per_cm_to_per_inch_invalid():
     with pytest.raises(ValueError):
         per_cm_to_per_inch(0)
+
+
+def test_stitches_for_inches():
+    assert stitches_for_inches(5.0, 4) == 20
+
+
+def test_stitches_for_inches_invalid_gauge():
+    with pytest.raises(ValueError):
+        stitches_for_inches(0, 4)
+
+
+def test_stitches_for_inches_invalid_inches():
+    with pytest.raises(ValueError):
+        stitches_for_inches(5.0, 0)
+
+
+def test_stitches_for_cm():
+    assert stitches_for_cm(2.0, 10) == 20
+
+
+def test_stitches_for_cm_invalid_gauge():
+    with pytest.raises(ValueError):
+        stitches_for_cm(0, 10)
+
+
+def test_stitches_for_cm_invalid_cm():
+    with pytest.raises(ValueError):
+        stitches_for_cm(2.0, 0)
 
 
 def test_inches_to_cm():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -6,6 +6,8 @@ from .gauge import (
     per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
+    stitches_for_cm,
+    stitches_for_inches,
     stitches_per_cm,
     stitches_per_inch,
 )
@@ -19,4 +21,6 @@ __all__ = [
     "rows_per_cm",
     "per_inch_to_per_cm",
     "per_cm_to_per_inch",
+    "stitches_for_inches",
+    "stitches_for_cm",
 ]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -151,3 +151,43 @@ def per_cm_to_per_inch(value: float) -> float:
     if value <= 0:
         raise ValueError("value must be positive")
     return value * CM_PER_INCH
+
+
+def stitches_for_inches(gauge: float, inches: float) -> int:
+    """Return the number of stitches needed for a width in inches.
+
+    Args:
+        gauge: Stitch gauge in stitches per inch. Must be > 0.
+        inches: Desired width in inches. Must be > 0.
+
+    Returns:
+        Required number of stitches rounded to the nearest whole number.
+
+    Raises:
+        ValueError: If ``gauge`` or ``inches`` is not positive.
+    """
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    return int(round(gauge * inches))
+
+
+def stitches_for_cm(gauge: float, cm: float) -> int:
+    """Return the number of stitches needed for a width in centimeters.
+
+    Args:
+        gauge: Stitch gauge in stitches per centimeter. Must be > 0.
+        cm: Desired width in centimeters. Must be > 0.
+
+    Returns:
+        Required number of stitches rounded to the nearest whole number.
+
+    Raises:
+        ValueError: If ``gauge`` or ``cm`` is not positive.
+    """
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    if cm <= 0:
+        raise ValueError("cm must be positive")
+    return int(round(gauge * cm))


### PR DESCRIPTION
## Summary
- add stitches_for_inches and stitches_for_cm to gauge utilities
- document cast-on helpers and fix README wording

## Testing
- `pre-commit run --all-files`
- `pytest`
- `bash scripts/checks.sh` *(import sort warning, linkchecker missing)*

------
https://chatgpt.com/codex/tasks/task_e_689eb73bc6c0832fa495ced49b4a0d6e