### PR TITLE
Add row count helpers for gauge calculations

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -19,6 +19,10 @@ from wove import (
     rows_per_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
+    stitches_for_inches,
+    stitches_for_cm,
+    rows_for_inches,
+    rows_for_cm,
 )
 
 stitches_per_inch(20, 4)   # 5.0 stitches per inch
@@ -27,7 +31,10 @@ stitches_per_cm(20, 10)    # 2.0 stitches per cm
 rows_per_cm(30, 10)        # 3.0 rows per cm
 per_cm_to_per_inch(2.0)    # 5.08
 per_inch_to_per_cm(5.08)   # ~2.0 per cm
+stitches_for_inches(5.0, 4)  # 20 stitches
 stitches_for_cm(2.0, 10)     # 20 stitches
+rows_for_inches(7.5, 4)      # 30 rows
+rows_for_cm(3.0, 10)         # 30 rows
 ```
 
 Each function checks that its inputs are positive and raises `ValueError`

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -7,6 +7,8 @@ from wove import (
     per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
+    rows_for_cm,
+    rows_for_inches,
     stitches_for_cm,
     stitches_for_inches,
     stitches_per_cm,
@@ -114,6 +116,34 @@ def test_stitches_for_cm_invalid_gauge():
 def test_stitches_for_cm_invalid_cm():
     with pytest.raises(ValueError):
         stitches_for_cm(2.0, 0)
+
+
+def test_rows_for_inches():
+    assert rows_for_inches(7.5, 4) == 30
+
+
+def test_rows_for_inches_invalid_gauge():
+    with pytest.raises(ValueError):
+        rows_for_inches(0, 4)
+
+
+def test_rows_for_inches_invalid_inches():
+    with pytest.raises(ValueError):
+        rows_for_inches(7.5, 0)
+
+
+def test_rows_for_cm():
+    assert rows_for_cm(3.0, 10) == 30
+
+
+def test_rows_for_cm_invalid_gauge():
+    with pytest.raises(ValueError):
+        rows_for_cm(0, 10)
+
+
+def test_rows_for_cm_invalid_cm():
+    with pytest.raises(ValueError):
+        rows_for_cm(3.0, 0)
 
 
 def test_inches_to_cm():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -6,6 +6,8 @@ from .gauge import (
     per_inch_to_per_cm,
     rows_per_cm,
     rows_per_inch,
+    rows_for_cm,
+    rows_for_inches,
     stitches_for_cm,
     stitches_for_inches,
     stitches_per_cm,
@@ -23,4 +25,6 @@ __all__ = [
     "per_cm_to_per_inch",
     "stitches_for_inches",
     "stitches_for_cm",
+    "rows_for_inches",
+    "rows_for_cm",
 ]

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -191,3 +191,43 @@ def stitches_for_cm(gauge: float, cm: float) -> int:
     if cm <= 0:
         raise ValueError("cm must be positive")
     return int(round(gauge * cm))
+
+
+def rows_for_inches(gauge: float, inches: float) -> int:
+    """Return the number of rows needed for a height in inches.
+
+    Args:
+        gauge: Row gauge in rows per inch. Must be > 0.
+        inches: Desired height in inches. Must be > 0.
+
+    Returns:
+        Required number of rows rounded to the nearest whole number.
+
+    Raises:
+        ValueError: If ``gauge`` or ``inches`` is not positive.
+    """
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    if inches <= 0:
+        raise ValueError("inches must be positive")
+    return int(round(gauge * inches))
+
+
+def rows_for_cm(gauge: float, cm: float) -> int:
+    """Return the number of rows needed for a height in centimeters.
+
+    Args:
+        gauge: Row gauge in rows per centimeter. Must be > 0.
+        cm: Desired height in centimeters. Must be > 0.
+
+    Returns:
+        Required number of rows rounded to the nearest whole number.
+
+    Raises:
+        ValueError: If ``gauge`` or ``cm`` is not positive.
+    """
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    if cm <= 0:
+        raise ValueError("cm must be positive")
+    return int(round(gauge * cm))


### PR DESCRIPTION
## Summary
- add `rows_for_inches` and `rows_for_cm` helpers
- document and test row count utilities

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8b091060832f84469a706950e696