### PR TITLE
✨ : – add width calculators for stitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Key features include:
 - Pre-commit hooks with spell checking via `pyspelling`.
 - Simple OpenSCAD scripts and STLs for hardware.
 - Utility functions such as stitch and row gauge calculators for inches and centimeters,
-  plus simple unit conversion helpers. See [docs/gauge.md](docs/gauge.md) for examples.
+  width estimators from stitch counts, and simple unit conversion helpers.
+  See [docs/gauge.md](docs/gauge.md) for examples.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts-codex.md`](docs/prompts-codex.md).
 

--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -3,7 +3,9 @@
 The `wove.gauge` module provides helpers for calculating stitch and row gauge,
 converting measurements between inches and centimeters, and estimating the
 number of stitches needed for a given width. Use `stitches_for_inches` or
-`stitches_for_cm` to calculate how many stitches a project requires.
+`stitches_for_cm` to calculate how many stitches a project requires, or
+`inches_for_stitches` and `cm_for_stitches` to determine width from a stitch
+count.
 
 To calculate gauge:
 
@@ -11,7 +13,8 @@ To calculate gauge:
 2. Block the swatch and lay it flat to relax the stitches.
 3. Measure in the middle of the swatch and count stitches across and rows down.
 4. Pass those counts and measurements to the helper functions shown below.
-5. Use `stitches_for_inches` or `stitches_for_cm` to estimate your cast-on.
+5. Use `stitches_for_inches` or `stitches_for_cm` to estimate your cast-on, or
+   `inches_for_stitches`/`cm_for_stitches` to check a pattern's finished size.
 
 ```python
 from wove import (
@@ -23,6 +26,8 @@ from wove import (
     per_inch_to_per_cm,
     stitches_for_inches,
     stitches_for_cm,
+    inches_for_stitches,
+    cm_for_stitches,
     rows_for_inches,
     rows_for_cm,
 )
@@ -37,6 +42,8 @@ rows_for_inches(7.5, 4)      # 30 rows
 rows_for_cm(3.0, 10)         # 30 rows
 stitches_for_inches(5.0, 7)   # 35 stitches for 7 in width
 stitches_for_cm(2.0, 10)      # 20 stitches for 10 cm width
+inches_for_stitches(35, 5.0)  # 7.0 inches for 35 stitches
+cm_for_stitches(20, 2.0)      # 10.0 cm for 20 stitches
 ```
 
 Each function checks that its inputs are positive and raises `ValueError`

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,7 +1,9 @@
 import pytest
 
 from wove import (
+    cm_for_stitches,
     cm_to_inches,
+    inches_for_stitches,
     inches_to_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
@@ -116,6 +118,34 @@ def test_stitches_for_cm_invalid_gauge():
 def test_stitches_for_cm_invalid_cm():
     with pytest.raises(ValueError):
         stitches_for_cm(2.0, 0)
+
+
+def test_inches_for_stitches():
+    assert inches_for_stitches(20, 5.0) == 4.0
+
+
+def test_inches_for_stitches_invalid_stitches():
+    with pytest.raises(ValueError):
+        inches_for_stitches(0, 5.0)
+
+
+def test_inches_for_stitches_invalid_gauge():
+    with pytest.raises(ValueError):
+        inches_for_stitches(20, 0)
+
+
+def test_cm_for_stitches():
+    assert cm_for_stitches(20, 2.0) == 10.0
+
+
+def test_cm_for_stitches_invalid_stitches():
+    with pytest.raises(ValueError):
+        cm_for_stitches(0, 2.0)
+
+
+def test_cm_for_stitches_invalid_gauge():
+    with pytest.raises(ValueError):
+        cm_for_stitches(20, 0)
 
 
 def test_rows_for_inches():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -1,13 +1,15 @@
 # isort: skip_file
 from .gauge import (
+    cm_for_stitches,
     cm_to_inches,
+    inches_for_stitches,
     inches_to_cm,
     per_cm_to_per_inch,
     per_inch_to_per_cm,
-    rows_per_cm,
-    rows_per_inch,
     rows_for_cm,
     rows_for_inches,
+    rows_per_cm,
+    rows_per_inch,
     stitches_for_cm,
     stitches_for_inches,
     stitches_per_cm,
@@ -15,7 +17,9 @@ from .gauge import (
 )
 
 __all__ = [
+    "cm_for_stitches",
     "cm_to_inches",
+    "inches_for_stitches",
     "inches_to_cm",
     "stitches_per_inch",
     "rows_per_inch",

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -231,3 +231,45 @@ def rows_for_cm(gauge: float, cm: float) -> int:
     if cm <= 0:
         raise ValueError("cm must be positive")
     return int(round(gauge * cm))
+
+
+def inches_for_stitches(stitches: int, gauge: float) -> float:
+    """Return the width in inches for a given stitch count.
+
+    Args:
+        stitches: Number of stitches. Must be > 0.
+        gauge: Stitch gauge in stitches per inch. Must be > 0.
+
+    Returns:
+        Width in inches.
+
+    Raises:
+        ValueError: If ``stitches`` or ``gauge`` is not positive.
+    """
+
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return stitches / gauge
+
+
+def cm_for_stitches(stitches: int, gauge: float) -> float:
+    """Return the width in centimeters for a given stitch count.
+
+    Args:
+        stitches: Number of stitches. Must be > 0.
+        gauge: Stitch gauge in stitches per centimeter. Must be > 0.
+
+    Returns:
+        Width in centimeters.
+
+    Raises:
+        ValueError: If ``stitches`` or ``gauge`` is not positive.
+    """
+
+    if stitches <= 0:
+        raise ValueError("stitches must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return stitches / gauge


### PR DESCRIPTION
what: add stitches->width helpers and document usage
why: compute finished width from stitch counts
how to test: pre-commit run --all-files && pytest && ./scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a57caf4db4832fa57f965ba0e645c8