### PR TITLE
📝 : add docs and tests prompt guides

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,6 @@ gauge
 styleguides/python
 prompts-codex
 prompts-codex-cad
+prompts-docs
+prompts-tests
 ```

--- a/docs/prompts-docs.md
+++ b/docs/prompts-docs.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Docs Prompt'
+slug: 'prompts-docs'
+---
+
+# Codex Docs Prompt
+
+Use this prompt when updating or creating documentation in Wove. It keeps written guides
+and references consistent.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository focused on documentation.
+
+PURPOSE:
+Maintain and improve Markdown docs.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- Docs live under `docs/`.
+- Ensure `pre-commit run --all-files` and `pytest` pass.
+- Keep lines ≤ 100 characters.
+
+REQUEST:
+1. Create or modify Markdown files in `docs/`.
+2. Validate spelling and links with `pre-commit`.
+3. Update `docs/index.md` when adding new pages.
+4. Run the commands listed above.
+
+OUTPUT:
+A pull request summarizing doc updates and test results.
+```

--- a/docs/prompts-tests.md
+++ b/docs/prompts-tests.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Test Prompt'
+slug: 'prompts-tests'
+---
+
+# Codex Test Prompt
+
+Use this prompt when adding or improving tests for Wove to ensure changes are well validated.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository focused on tests.
+
+PURPOSE:
+Increase test coverage and reliability.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- Tests live under `tests/`.
+- Use `pytest` to write and run tests.
+- Ensure `pre-commit run --all-files` and `pytest` pass.
+
+REQUEST:
+1. Add a failing test that demonstrates the desired improvement.
+2. Implement code to make the test pass.
+3. Keep tests deterministic and isolated.
+4. Run the commands listed above.
+
+OUTPUT:
+A pull request describing test additions and results.
+```


### PR DESCRIPTION
## Summary
- add Codex Docs Prompt for editing repository docs
- add Codex Test Prompt for writing and improving tests
- update docs index to expose new prompt guides

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cbd8a828832faee17620f6231a74