### PR TITLE
📝 add docs prompts for docs and CI fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,6 @@ gauge
 styleguides/python
 prompts-codex
 prompts-codex-cad
+prompts-codex-docs
+prompts-codex-ci-fix
 ```

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# Codex CI-Failure Fix Prompt
+
+Use this prompt to diagnose and resolve continuous integration failures in Wove.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository.
+
+PURPOSE:
+Diagnose and fix CI failures so tests and checks pass.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- Install dependencies with `pip install -r requirements.txt` if needed.
+- Run `pre-commit run --all-files` and `pytest`.
+
+REQUEST:
+1. Reproduce the failing check locally with `pre-commit run --all-files`.
+2. Investigate failures and apply minimal fixes.
+3. Rerun `pre-commit run --all-files` and `pytest` until they succeed.
+4. Commit with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the fix and passing checks.
+```
+
+Copy this block when CI needs attention in Wove.

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Docs Prompt'
+slug: 'prompts-codex-docs'
+---
+
+# Codex Docs Prompt
+
+Use this prompt to improve or fix Wove documentation.
+
+```
+SYSTEM:
+You are an automated contributor for the wove repository.
+
+GOAL:
+Enhance documentation accuracy, clarity, or completeness.
+
+CONTEXT:
+- Follow AGENTS.md and README.md.
+- Run `pre-commit run --all-files` and `pytest`.
+
+REQUEST:
+1. Locate outdated, unclear, or missing sections in `docs/`.
+2. Apply concise updates following existing style.
+3. Verify links and references work.
+4. Run the commands above to ensure tests pass.
+
+OUTPUT:
+A pull request summarizing documentation updates.
+```
+
+Copy this block when Wove docs need attention.


### PR DESCRIPTION
## Summary
- document codex prompts for docs updates and CI failure fixes
- list new prompt docs in the docs index

## Testing
- `pre-commit run --all-files`
- `pytest`
- `git diff --cached | ./scripts/scan-secrets.py` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cbd8a828832faee17620f6231a74