### PR TITLE
✅: round .5 values up in gauge helpers

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -7,6 +7,9 @@ number of stitches needed for a given width. Use `stitches_for_inches` or
 `inches_for_stitches` and `cm_for_stitches` to determine width from a stitch
 count.
 
+Values ending in `.5` are rounded up when using `stitches_for_inches`,
+`stitches_for_cm`, `rows_for_inches`, or `rows_for_cm`.
+
 To calculate gauge:
 
 1. Knit a swatch at least 4 in (10 cm) square.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -192,3 +192,11 @@ def test_cm_to_inches():
 def test_cm_to_inches_invalid():
     with pytest.raises(ValueError):
         cm_to_inches(-1)
+
+
+def test_stitches_for_inches_half_up():
+    assert stitches_for_inches(2.5, 1) == 3
+
+
+def test_rows_for_cm_half_up():
+    assert rows_for_cm(2.5, 1) == 3

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import math
+
 CM_PER_INCH = 2.54
+
+
+def _round_half_up(value: float) -> int:
+    """Round a positive float to the nearest int with halves rounding up."""
+    return int(math.floor(value + 0.5))
 
 
 def inches_to_cm(inches: float) -> float:
@@ -162,6 +169,7 @@ def stitches_for_inches(gauge: float, inches: float) -> int:
 
     Returns:
         Required number of stitches rounded to the nearest whole number.
+        Values ending in .5 are rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``inches`` is not positive.
@@ -170,7 +178,7 @@ def stitches_for_inches(gauge: float, inches: float) -> int:
         raise ValueError("gauge must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
-    return int(round(gauge * inches))
+    return _round_half_up(gauge * inches)
 
 
 def stitches_for_cm(gauge: float, cm: float) -> int:
@@ -182,6 +190,7 @@ def stitches_for_cm(gauge: float, cm: float) -> int:
 
     Returns:
         Required number of stitches rounded to the nearest whole number.
+        Values ending in .5 are rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``cm`` is not positive.
@@ -190,7 +199,7 @@ def stitches_for_cm(gauge: float, cm: float) -> int:
         raise ValueError("gauge must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
-    return int(round(gauge * cm))
+    return _round_half_up(gauge * cm)
 
 
 def rows_for_inches(gauge: float, inches: float) -> int:
@@ -202,6 +211,7 @@ def rows_for_inches(gauge: float, inches: float) -> int:
 
     Returns:
         Required number of rows rounded to the nearest whole number.
+        Values ending in .5 are rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``inches`` is not positive.
@@ -210,7 +220,7 @@ def rows_for_inches(gauge: float, inches: float) -> int:
         raise ValueError("gauge must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
-    return int(round(gauge * inches))
+    return _round_half_up(gauge * inches)
 
 
 def rows_for_cm(gauge: float, cm: float) -> int:
@@ -222,6 +232,7 @@ def rows_for_cm(gauge: float, cm: float) -> int:
 
     Returns:
         Required number of rows rounded to the nearest whole number.
+        Values ending in .5 are rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``cm`` is not positive.
@@ -230,7 +241,7 @@ def rows_for_cm(gauge: float, cm: float) -> int:
         raise ValueError("gauge must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
-    return int(round(gauge * cm))
+    return _round_half_up(gauge * cm)
 
 
 def inches_for_stitches(stitches: int, gauge: float) -> float:


### PR DESCRIPTION
## What
- test and fix half-up rounding for stitch/row calculators
- document new rounding behavior

## Why
- Python's round uses banker's rounding which surprised users

## How to Test
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a813e6c244832fa2623a83b42500da