### PR TITLE
🧪: round half up for gauge counts

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -47,4 +47,6 @@ cm_for_stitches(20, 2.0)      # 10.0 cm for 20 stitches
 ```
 
 Each function checks that its inputs are positive and raises `ValueError`
-when an invalid value is supplied.
+when an invalid value is supplied. Conversions from gauge to counts
+use standard arithmetic rounding so that `.5` values round up instead of
+down.

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -106,6 +106,10 @@ def test_stitches_for_inches_invalid_inches():
         stitches_for_inches(5.0, 0)
 
 
+def test_stitches_for_inches_rounds_half_up():
+    assert stitches_for_inches(5.0, 0.5) == 3
+
+
 def test_stitches_for_cm():
     assert stitches_for_cm(2.0, 10) == 20
 
@@ -118,6 +122,10 @@ def test_stitches_for_cm_invalid_gauge():
 def test_stitches_for_cm_invalid_cm():
     with pytest.raises(ValueError):
         stitches_for_cm(2.0, 0)
+
+
+def test_stitches_for_cm_rounds_half_up():
+    assert stitches_for_cm(2.0, 1.25) == 3
 
 
 def test_inches_for_stitches():
@@ -162,6 +170,10 @@ def test_rows_for_inches_invalid_inches():
         rows_for_inches(7.5, 0)
 
 
+def test_rows_for_inches_rounds_half_up():
+    assert rows_for_inches(5.0, 0.5) == 3
+
+
 def test_rows_for_cm():
     assert rows_for_cm(3.0, 10) == 30
 
@@ -174,6 +186,10 @@ def test_rows_for_cm_invalid_gauge():
 def test_rows_for_cm_invalid_cm():
     with pytest.raises(ValueError):
         rows_for_cm(3.0, 0)
+
+
+def test_rows_for_cm_rounds_half_up():
+    assert rows_for_cm(2.0, 1.25) == 3
 
 
 def test_inches_to_cm():

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import math
+
 CM_PER_INCH = 2.54
+
+
+def _round_half_up(value: float) -> int:
+    """Return ``value`` rounded to the nearest whole number with .5 rounding up."""
+    return math.floor(value + 0.5)
 
 
 def inches_to_cm(inches: float) -> float:
@@ -161,7 +168,8 @@ def stitches_for_inches(gauge: float, inches: float) -> int:
         inches: Desired width in inches. Must be > 0.
 
     Returns:
-        Required number of stitches rounded to the nearest whole number.
+        Required number of stitches rounded to the nearest whole number with `.5` values
+        rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``inches`` is not positive.
@@ -170,7 +178,7 @@ def stitches_for_inches(gauge: float, inches: float) -> int:
         raise ValueError("gauge must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
-    return int(round(gauge * inches))
+    return _round_half_up(gauge * inches)
 
 
 def stitches_for_cm(gauge: float, cm: float) -> int:
@@ -181,7 +189,8 @@ def stitches_for_cm(gauge: float, cm: float) -> int:
         cm: Desired width in centimeters. Must be > 0.
 
     Returns:
-        Required number of stitches rounded to the nearest whole number.
+        Required number of stitches rounded to the nearest whole number with `.5` values
+        rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``cm`` is not positive.
@@ -190,7 +199,7 @@ def stitches_for_cm(gauge: float, cm: float) -> int:
         raise ValueError("gauge must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
-    return int(round(gauge * cm))
+    return _round_half_up(gauge * cm)
 
 
 def rows_for_inches(gauge: float, inches: float) -> int:
@@ -201,7 +210,8 @@ def rows_for_inches(gauge: float, inches: float) -> int:
         inches: Desired height in inches. Must be > 0.
 
     Returns:
-        Required number of rows rounded to the nearest whole number.
+        Required number of rows rounded to the nearest whole number with `.5` values
+        rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``inches`` is not positive.
@@ -210,7 +220,7 @@ def rows_for_inches(gauge: float, inches: float) -> int:
         raise ValueError("gauge must be positive")
     if inches <= 0:
         raise ValueError("inches must be positive")
-    return int(round(gauge * inches))
+    return _round_half_up(gauge * inches)
 
 
 def rows_for_cm(gauge: float, cm: float) -> int:
@@ -221,7 +231,8 @@ def rows_for_cm(gauge: float, cm: float) -> int:
         cm: Desired height in centimeters. Must be > 0.
 
     Returns:
-        Required number of rows rounded to the nearest whole number.
+        Required number of rows rounded to the nearest whole number with `.5` values
+        rounded up.
 
     Raises:
         ValueError: If ``gauge`` or ``cm`` is not positive.
@@ -230,7 +241,7 @@ def rows_for_cm(gauge: float, cm: float) -> int:
         raise ValueError("gauge must be positive")
     if cm <= 0:
         raise ValueError("cm must be positive")
-    return int(round(gauge * cm))
+    return _round_half_up(gauge * cm)
 
 
 def inches_for_stitches(stitches: int, gauge: float) -> float:


### PR DESCRIPTION
## What
- round half up when converting gauge to counts
- document rounding behavior

## Why
- avoid underestimating stitches and rows

## How to Test
- `pre-commit run --all-files`
- `pytest`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a813e6c244832fa2623a83b42500da