### PR TITLE
📝 : – add Markdown style guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,5 +18,6 @@ Then open `docs/_build/html/index.html` in a browser.
 - [Robotic Knitting Machine](robotic-knitting-machine.md)
 - [Gauge utilities](gauge.md)
 - [Python Style Guide](styleguides/python.md)
+- [Markdown Style Guide](styleguides/markdown.md)
 - [Codex Prompt](prompts-codex.md)
 - [Codex CAD Prompt](prompts-codex-cad.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ crochet-basics
 robotic-knitting-machine
 gauge
 styleguides/python
+styleguides/markdown
 prompts-codex
 prompts-codex-cad
 prompts-docs

--- a/docs/styleguides/markdown.md
+++ b/docs/styleguides/markdown.md
@@ -1,0 +1,9 @@
+# Markdown Style Guide
+
+Follow these rules to keep our docs consistent:
+
+- Wrap lines at 100 characters or fewer.
+- Use fenced code blocks with language tags when including code.
+- Prefer relative links to documents within the repository.
+- Use sentence case for headings and link titles.
+- Run `pre-commit run --all-files` to check spelling and links before committing.


### PR DESCRIPTION
what: add Markdown style guide and link from docs
why: document conventions for contributors
how to test: pre-commit run --all-files; pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a813e5ed64832f8943c57c0473a04e