### PR TITLE
docs: add contributing docs guide

### DIFF
--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -1,0 +1,13 @@
+# Contributing to documentation
+
+Maintainers welcome improvements to any files in the `docs/` directory.
+Follow these steps to keep the documentation consistent and healthy:
+
+1. Wrap lines at 100 characters or fewer.
+2. Follow the [Markdown style guide](styleguides/markdown.md) for headings, links, and code blocks.
+3. Run `pre-commit run --all-files` to validate spelling and links.
+4. Run `pytest` to ensure examples and tooling remain intact.
+5. Update `docs/index.md` when adding new pages.
+6. Use relative links within the repository.
+
+These steps help keep our documentation clear, accurate, and easy to maintain.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ robotic-knitting-machine
 gauge
 styleguides/python
 styleguides/markdown
+contributing-docs
 prompts-codex
 prompts-codex-cad
 prompts-docs


### PR DESCRIPTION
## Summary
- add guide for contributing to docs
- include new page in Sphinx index

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92dffb998832f8c4fc2f425327257