### PR TITLE
🐛 : reject negative values in _round_half_up

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -8,7 +8,8 @@ project requires, or `inches_for_stitches` and `cm_for_stitches` to determine
 width from a stitch count.
 
 Values ending in `.5` are rounded up when using `stitches_for_inches`,
-`stitches_for_cm`, `rows_for_inches`, or `rows_for_cm`.
+`stitches_for_cm`, `rows_for_inches`, or `rows_for_cm`; negative values are
+rejected.
 
 To calculate gauge:
 

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -18,6 +18,7 @@ from wove import (
     stitches_per_inch,
     yards_to_meters,
 )
+from wove.gauge import _round_half_up
 
 
 def test_stitches_per_inch():
@@ -220,3 +221,8 @@ def test_stitches_for_inches_half_up():
 
 def test_rows_for_cm_half_up():
     assert rows_for_cm(2.5, 1) == 3
+
+
+def test_round_half_up_invalid():
+    with pytest.raises(ValueError):
+        _round_half_up(-0.1)

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -5,9 +5,15 @@ import math
 CM_PER_INCH = 2.54
 M_PER_YARD = 0.9144
 
-
 def _round_half_up(value: float) -> int:
-    """Round a positive float to the nearest int with halves rounding up."""
+    """Round a non-negative float to the nearest int with halves rounding up.
+
+    Raises:
+        ValueError: If ``value`` is negative.
+    """
+
+    if value < 0:
+        raise ValueError("value must be non-negative")
     return int(math.floor(value + 0.5))
 
 


### PR DESCRIPTION
what: guard _round_half_up against negative inputs and document behavior.
why: ensure rounding helper matches docs and avoids unintended results.
how to test: pre-commit run --all-files && pytest

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92df58928832fadbe66d63dce5772