### PR TITLE
✨ : add row-to-length helpers

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -2,10 +2,11 @@
 
 The `wove.gauge` module provides helpers for calculating stitch and row gauge,
 converting measurements between inches, centimeters, yards, and meters, and
-estimating the number of stitches needed for a given width. Use
+estimating the number of stitches or rows needed for a given size. Use
 `stitches_for_inches` or `stitches_for_cm` to calculate how many stitches a
-project requires, or `inches_for_stitches` and `cm_for_stitches` to determine
-width from a stitch count.
+project requires, and `rows_for_inches` or `rows_for_cm` for row counts. To
+determine dimensions from counts, use `inches_for_stitches`/`cm_for_stitches`
+for width and the new `inches_for_rows`/`cm_for_rows` helpers for height.
 
 Values ending in `.5` are rounded up when using `stitches_for_inches`,
 `stitches_for_cm`, `rows_for_inches`, or `rows_for_cm`.
@@ -31,6 +32,8 @@ from wove import (
     stitches_for_cm,
     inches_for_stitches,
     cm_for_stitches,
+    inches_for_rows,
+    cm_for_rows,
     rows_for_inches,
     rows_for_cm,
     yards_to_meters,
@@ -49,6 +52,8 @@ stitches_for_inches(5.0, 7)   # 35 stitches for 7 in width
 stitches_for_cm(2.0, 10)      # 20 stitches for 10 cm width
 inches_for_stitches(35, 5.0)  # 7.0 inches for 35 stitches
 cm_for_stitches(20, 2.0)      # 10.0 cm for 20 stitches
+inches_for_rows(30, 7.5)      # 4.0 inches for 30 rows
+cm_for_rows(30, 3.0)          # 10.0 cm for 30 rows
 yards_to_meters(1.0)         # 0.9144 meters
 meters_to_yards(0.9144)      # ~1.0 yard
 ```

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -2,8 +2,10 @@ import pytest
 
 from wove import (
     cm_for_stitches,
+    cm_for_rows,
     cm_to_inches,
     inches_for_stitches,
+    inches_for_rows,
     inches_to_cm,
     meters_to_yards,
     per_cm_to_per_inch,
@@ -148,6 +150,34 @@ def test_cm_for_stitches_invalid_stitches():
 def test_cm_for_stitches_invalid_gauge():
     with pytest.raises(ValueError):
         cm_for_stitches(20, 0)
+
+
+def test_inches_for_rows():
+    assert inches_for_rows(30, 7.5) == 4.0
+
+
+def test_inches_for_rows_invalid_rows():
+    with pytest.raises(ValueError):
+        inches_for_rows(0, 7.5)
+
+
+def test_inches_for_rows_invalid_gauge():
+    with pytest.raises(ValueError):
+        inches_for_rows(30, 0)
+
+
+def test_cm_for_rows():
+    assert cm_for_rows(30, 3.0) == 10.0
+
+
+def test_cm_for_rows_invalid_rows():
+    with pytest.raises(ValueError):
+        cm_for_rows(0, 3.0)
+
+
+def test_cm_for_rows_invalid_gauge():
+    with pytest.raises(ValueError):
+        cm_for_rows(30, 0)
 
 
 def test_rows_for_inches():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -2,7 +2,9 @@
 from .gauge import (
     cm_for_stitches,
     cm_to_inches,
+    cm_for_rows,
     inches_for_stitches,
+    inches_for_rows,
     inches_to_cm,
     meters_to_yards,
     per_cm_to_per_inch,
@@ -21,7 +23,9 @@ from .gauge import (
 __all__ = [
     "cm_for_stitches",
     "cm_to_inches",
+    "cm_for_rows",
     "inches_for_stitches",
+    "inches_for_rows",
     "inches_to_cm",
     "meters_to_yards",
     "stitches_per_inch",

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -321,3 +321,45 @@ def cm_for_stitches(stitches: int, gauge: float) -> float:
     if gauge <= 0:
         raise ValueError("gauge must be positive")
     return stitches / gauge
+
+
+def inches_for_rows(rows: int, gauge: float) -> float:
+    """Return the height in inches for a given row count.
+
+    Args:
+        rows: Number of rows. Must be > 0.
+        gauge: Row gauge in rows per inch. Must be > 0.
+
+    Returns:
+        Height in inches.
+
+    Raises:
+        ValueError: If ``rows`` or ``gauge`` is not positive.
+    """
+
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return rows / gauge
+
+
+def cm_for_rows(rows: int, gauge: float) -> float:
+    """Return the height in centimeters for a given row count.
+
+    Args:
+        rows: Number of rows. Must be > 0.
+        gauge: Row gauge in rows per centimeter. Must be > 0.
+
+    Returns:
+        Height in centimeters.
+
+    Raises:
+        ValueError: If ``rows`` or ``gauge`` is not positive.
+    """
+
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return rows / gauge


### PR DESCRIPTION
## Summary
- expose inches_for_rows and cm_for_rows to convert row counts into height
- document row height helpers in gauge guide
- test new conversion utilities

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92df58928832fadbe66d63dce5772