### PR TITLE
Add row height conversion helpers

### DIFF
--- a/docs/gauge.md
+++ b/docs/gauge.md
@@ -5,7 +5,8 @@ converting measurements between inches, centimeters, yards, and meters, and
 estimating the number of stitches needed for a given width. Use
 `stitches_for_inches` or `stitches_for_cm` to calculate how many stitches a
 project requires, or `inches_for_stitches` and `cm_for_stitches` to determine
-width from a stitch count.
+width from a stitch count. Use `inches_for_rows` and `cm_for_rows` to convert a
+row count back to height.
 
 Values ending in `.5` are rounded up when using `stitches_for_inches`,
 `stitches_for_cm`, `rows_for_inches`, or `rows_for_cm`.
@@ -29,6 +30,8 @@ from wove import (
     per_inch_to_per_cm,
     stitches_for_inches,
     stitches_for_cm,
+    inches_for_rows,
+    cm_for_rows,
     inches_for_stitches,
     cm_for_stitches,
     rows_for_inches,
@@ -47,6 +50,8 @@ per_cm_to_per_inch(2.0)    # 5.08
 per_inch_to_per_cm(5.08)   # ~2.0 per cm
 rows_for_inches(7.5, 4)      # 30 rows
 rows_for_cm(3.0, 10)         # 30 rows
+inches_for_rows(30, 7.5)     # 4.0 inches for 30 rows
+cm_for_rows(30, 3.0)         # 10.0 cm for 30 rows
 stitches_for_inches(5.0, 7)   # 35 stitches for 7 in width
 stitches_for_cm(2.0, 10)      # 20 stitches for 10 cm width
 inches_for_stitches(35, 5.0)  # 7.0 inches for 35 stitches

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -5,8 +5,10 @@
 import pytest
 
 from wove import (
+    cm_for_rows,
     cm_for_stitches,
     cm_to_inches,
+    inches_for_rows,
     inches_for_stitches,
     inches_to_cm,
     inches_to_yards,
@@ -182,6 +184,34 @@ def test_rows_for_cm_invalid_gauge():
 def test_rows_for_cm_invalid_cm():
     with pytest.raises(ValueError):
         rows_for_cm(3.0, 0)
+
+
+def test_inches_for_rows():
+    assert inches_for_rows(30, 7.5) == 4.0
+
+
+def test_inches_for_rows_invalid_rows():
+    with pytest.raises(ValueError):
+        inches_for_rows(0, 7.5)
+
+
+def test_inches_for_rows_invalid_gauge():
+    with pytest.raises(ValueError):
+        inches_for_rows(30, 0)
+
+
+def test_cm_for_rows():
+    assert cm_for_rows(30, 3.0) == 10.0
+
+
+def test_cm_for_rows_invalid_rows():
+    with pytest.raises(ValueError):
+        cm_for_rows(0, 3.0)
+
+
+def test_cm_for_rows_invalid_gauge():
+    with pytest.raises(ValueError):
+        cm_for_rows(30, 0)
 
 
 def test_inches_to_cm():

--- a/wove/__init__.py
+++ b/wove/__init__.py
@@ -2,7 +2,9 @@
 from .gauge import (
     cm_for_stitches,
     cm_to_inches,
+    cm_for_rows,
     inches_for_stitches,
+    inches_for_rows,
     inches_to_cm,
     inches_to_yards,
     meters_to_yards,
@@ -23,7 +25,9 @@ from .gauge import (
 __all__ = [
     "cm_for_stitches",
     "cm_to_inches",
+    "cm_for_rows",
     "inches_for_stitches",
+    "inches_for_rows",
     "inches_to_cm",
     "inches_to_yards",
     "meters_to_yards",

--- a/wove/gauge.py
+++ b/wove/gauge.py
@@ -318,6 +318,48 @@ def rows_for_cm(gauge: float, cm: float) -> int:
     return _round_half_up(gauge * cm)
 
 
+def inches_for_rows(rows: int, gauge: float) -> float:
+    """Return the height in inches for a given row count.
+
+    Args:
+        rows: Number of rows. Must be > 0.
+        gauge: Row gauge in rows per inch. Must be > 0.
+
+    Returns:
+        Height in inches.
+
+    Raises:
+        ValueError: If ``rows`` or ``gauge`` is not positive.
+    """
+
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return rows / gauge
+
+
+def cm_for_rows(rows: int, gauge: float) -> float:
+    """Return the height in centimeters for a given row count.
+
+    Args:
+        rows: Number of rows. Must be > 0.
+        gauge: Row gauge in rows per centimeter. Must be > 0.
+
+    Returns:
+        Height in centimeters.
+
+    Raises:
+        ValueError: If ``rows`` or ``gauge`` is not positive.
+    """
+
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if gauge <= 0:
+        raise ValueError("gauge must be positive")
+    return rows / gauge
+
+
 def inches_for_stitches(stitches: int, gauge: float) -> float:
     """Return the width in inches for a given stitch count.
 


### PR DESCRIPTION
## Summary
- add inches_for_rows and cm_for_rows for converting row counts to height
- document new helpers in gauge docs
- cover new conversions with tests

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a966f0fd7c832f9bc23bc2019e06b8