### PR TITLE
📝 : – Add Codex implement prompt documentation

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -126,3 +126,4 @@ AllFreeCrochet
 Knitty
 Swatching
 VeryPink
+TODOs

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,5 +20,6 @@ Then open `docs/_build/html/index.html` in a browser.
 - [Python Style Guide](styleguides/python.md)
 - [Markdown Style Guide](styleguides/markdown.md)
 - [Codex Prompt](prompts-codex.md)
+- [Codex Implement Prompt](prompts-codex-implement.md)
 - [Codex CAD Prompt](prompts-codex-cad.md)
 - [Testing](testing.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ glossary
 styleguides/python
 styleguides/markdown
 prompts-codex
+prompts-codex-implement
 prompts-codex-cad
 prompts-docs
 prompts-tests

--- a/docs/prompts-codex-implement.md
+++ b/docs/prompts-codex-implement.md
@@ -1,0 +1,69 @@
+---
+title: 'Wove Implement Prompt'
+slug: 'codex-implement'
+---
+
+# Codex Implement Prompt
+
+Type: evergreen · One-click: yes
+
+Use this prompt when you want an automated agent to deliver a production-ready
+feature that has been promised but not yet built in the Wove project.
+
+```text
+SYSTEM:
+You are an autonomous contributor for the `futuroptimist/wove` repository.
+Follow the guidance in AGENTS.md, README.md, and any scoped prompt docs.
+Keep the repository healthy by ensuring `pre-commit run --all-files` and
+`pytest` both succeed before committing.
+
+USER:
+1. Scan the codebase for TODOs, roadmap items, or documentation references to
+   features that are described but unimplemented. Randomly select one that is
+   still relevant and within a single PR scope.
+2. Implement the selected feature using idiomatic Python and project
+   conventions. Touch only the files necessary to ship the feature.
+3. Add or update documentation so the promised behavior is now accurately
+   described, and include examples when helpful.
+4. Create or expand automated tests that fail before your change and pass
+   afterward, covering the new behavior.
+5. Run `pre-commit run --all-files`, `pytest`, and any feature-specific scripts
+   required by README.md. Fix issues until the checks pass cleanly.
+6. Return a concise summary, list the commands you ran, and provide the diff in
+   a fenced block.
+
+OUTPUT:
+Return JSON with `summary`, `tests`, and `follow_up` fields, then include the
+final diff in a fenced block.
+```
+
+## Usage notes
+
+- Favor features that unblock existing documentation or tests.
+- Prefer minimal, vertical slices that can be reviewed quickly.
+- Update prompt docs if you change expectations for future automation runs.
+- Keep commit messages focused; capture context in the PR description.
+
+## Upgrade Prompt
+
+Type: evergreen
+
+Use this prompt when the implement prompt or related docs need refinement.
+
+```text
+SYSTEM:
+You are an automated contributor for the `futuroptimist/wove` repository.
+Follow AGENTS.md, README.md, and docs/styleguides/ for conventions.
+Ensure `pre-commit run --all-files` and `pytest` succeed before finalizing.
+
+USER:
+1. Choose one prompt file under `docs/` related to Codex automation.
+2. Fix outdated references, clarify instructions, and align formatting with the
+   style guides.
+3. Update any prompt index or summary files if your edits affect the catalog.
+4. Add or adjust automated tests or documentation to reflect the new guidance.
+5. Run the required checks above and resolve all warnings.
+
+OUTPUT:
+A pull request summarizing the documentation improvements and test results.
+```


### PR DESCRIPTION
what: add a codex implement prompt doc and link it in indexes
why: provide automation guidance for shipping promised features
how to test: pytest; pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68db65715124832fafa59c1e531507e3