### PR TITLE
🧹 : – Fix CAD docs test assertion formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = .git,.venv

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = .git,.venv
+extend-exclude = .git,.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 88
-force-exclude = "(?x)(\n  ^\\.git/\n  |^\\.venv/\n)"
+force-exclude = "(?x)(\n  (^|/)\\.git/\n  |(^|/)\\.venv/\n)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+force-exclude = "(?x)(\n  ^\\.git/\n  |^\\.venv/\n)"

--- a/tests/test_cad_docs.py
+++ b/tests/test_cad_docs.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 CAD_DIR = Path(__file__).resolve().parents[1] / "cad"
 CAD_README = CAD_DIR / "README.md"
-CAD_README_DESCRIPTION_MSG = "cad/README.md should describe hardware modules"
+CAD_README_DESCRIPTION_MSG = "CAD README must describe hardware modules"
+CAD_README_MISSING_MODULE_MSG = "Missing CAD README modules: {modules}"
 
 
 def test_cad_readme_exists() -> None:
@@ -17,4 +20,7 @@ def test_cad_readme_lists_all_modules() -> None:
     content = CAD_README.read_text(encoding="utf-8")
     scad_files = sorted(CAD_DIR.glob("*.scad"))
     missing = [path.name for path in scad_files if path.stem not in content]
-    assert not missing, f"Missing module entries in CAD README: {missing}"
+    if missing:
+        missing_modules = ", ".join(missing)
+        message = CAD_README_MISSING_MODULE_MSG.format(modules=missing_modules)
+        pytest.fail(message)

--- a/tests/test_cad_docs.py
+++ b/tests/test_cad_docs.py
@@ -9,11 +9,16 @@ CAD_README = CAD_DIR / "README.md"
 
 
 def test_cad_readme_exists() -> None:
-    assert CAD_README.exists(), "cad/README.md should describe hardware modules"
+    assert CAD_README.exists(), (
+        "cad/README.md should describe hardware modules"
+    )
 
 
 def test_cad_readme_lists_all_modules() -> None:
     content = CAD_README.read_text(encoding="utf-8")
     scad_files = sorted(CAD_DIR.glob("*.scad"))
     missing = [path.name for path in scad_files if path.stem not in content]
-    assert not missing, f"Missing module entries in CAD README: {missing}"
+    assert not missing, (
+        "Missing module entries in CAD README: "
+        f"{missing}"
+    )

--- a/tests/test_cad_docs.py
+++ b/tests/test_cad_docs.py
@@ -6,19 +6,15 @@ from pathlib import Path
 
 CAD_DIR = Path(__file__).resolve().parents[1] / "cad"
 CAD_README = CAD_DIR / "README.md"
+CAD_README_DESCRIPTION_MSG = "cad/README.md should describe hardware modules"
 
 
 def test_cad_readme_exists() -> None:
-    assert CAD_README.exists(), (
-        "cad/README.md should describe hardware modules"
-    )
+    assert CAD_README.exists(), CAD_README_DESCRIPTION_MSG
 
 
 def test_cad_readme_lists_all_modules() -> None:
     content = CAD_README.read_text(encoding="utf-8")
     scad_files = sorted(CAD_DIR.glob("*.scad"))
     missing = [path.name for path in scad_files if path.stem not in content]
-    assert not missing, (
-        "Missing module entries in CAD README: "
-        f"{missing}"
-    )
+    assert not missing, f"Missing module entries in CAD README: {missing}"

--- a/tests/test_cad_docs.py
+++ b/tests/test_cad_docs.py
@@ -1,4 +1,5 @@
 """Ensure CAD documentation covers all modules."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -8,9 +9,7 @@ CAD_README = CAD_DIR / "README.md"
 
 
 def test_cad_readme_exists() -> None:
-    assert CAD_README.exists(), (
-        "cad/README.md should describe hardware modules"
-    )
+    assert CAD_README.exists(), "cad/README.md should describe hardware modules"
 
 
 def test_cad_readme_lists_all_modules() -> None:


### PR DESCRIPTION
what: format CAD docs assertion to satisfy black
why: unblock lint-format job failing on black
how to test: pre-commit run --all-files; pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1aa4cd628832f93cebb2386fcab13