### PR TITLE
✨ : – expand prompt summary descriptions

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -10,7 +10,7 @@ Update `dict/prompt-doc-repos.txt` to control which repositories appear.
   agents) to contribute to the Wove repository. Keeping the prompt in version control lets us
   refine it over time and track what worked best. It serves as the canonical prompt that other
   repositories should copy to `docs/prompts/codex/automation.md` for consistent automation. For
-  propagation instructions, see [propagate.md](propagate.md).
+  propagation instructions, see propagate.md.
 
 - **Codex CAD Prompt** (`evergreen`) — `docs/prompts/codex/cad.md`
   Use this prompt when generating or updating OpenSCAD modules for Wove. It keeps 3D assets and

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -6,19 +6,28 @@ Update `dict/prompt-doc-repos.txt` to control which repositories appear.
 ## wove
 
 - **Codex Automation Prompt** (`evergreen`) — `docs/prompts/codex/automation.md`
-  This document stores the baseline prompt used when instructing OpenAI Codex (or
+  This document stores the baseline prompt used when instructing OpenAI Codex (or compatible
+  agents) to contribute to the Wove repository. Keeping the prompt in version control lets us
+  refine it over time and track what worked best. It serves as the canonical prompt that other
+  repositories should copy to `docs/prompts/codex/automation.md` for consistent automation. For
+  propagation instructions, see [propagate.md](propagate.md).
 
 - **Codex CAD Prompt** (`evergreen`) — `docs/prompts/codex/cad.md`
-  Use this prompt when generating or updating OpenSCAD modules for Wove. It keeps
+  Use this prompt when generating or updating OpenSCAD modules for Wove. It keeps 3D assets and
+  their exported models in sync.
 
 - **Codex Docs Prompt** (`evergreen`) — `docs/prompts/codex/docs.md`
-  Use this prompt when updating or creating documentation in Wove. It keeps
+  Use this prompt when updating or creating documentation in Wove. It keeps written guides and
+  references consistent.
 
 - **Codex Implement Prompt** (`evergreen`) — `docs/prompts/codex/implement.md`
-  Use this prompt when you want an automated agent to deliver a production-ready
+  Use this prompt when you want an automated agent to deliver a production-ready feature that
+  has been promised but not yet built in the Wove project.
 
 - **Codex Prompt Propagation Guide** (`evergreen`) — `docs/prompts/codex/propagate.md`
-  Use this guide when copying Wove's Codex prompt catalog into another repository or
+  Use this guide when copying Wove's Codex prompt catalog into another repository or rotating a
+  fresh automation setup. It documents the lightweight checklist for keeping prompt docs
+  synchronized with downstream projects.
 
 - **Codex Test Prompt** (`evergreen`) — `docs/prompts/codex/tests.md`
-  Use this prompt when adding or improving tests for Wove to ensure changes are
+  Use this prompt when adding or improving tests for Wove to ensure changes are well validated.

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -150,9 +150,12 @@ def _extract_type(lines: List[str]) -> str | None:
 
 def _extract_description(lines: List[str]) -> str | None:
     after_type = False
+    paragraph: List[str] = []
     for line in lines:
         stripped = line.strip()
         if not stripped:
+            if paragraph:
+                break
             continue
         if stripped.lower().startswith("type:"):
             after_type = True
@@ -164,8 +167,10 @@ def _extract_description(lines: List[str]) -> str | None:
         if stripped.startswith("```"):
             # Skip code blocks that appear before any narrative description.
             return None
-        return stripped
-    return None
+        paragraph.append(stripped)
+    if not paragraph:
+        return None
+    return " ".join(paragraph)
 
 
 def render_summary(docs: Sequence[PromptDoc]) -> str:

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import re
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
@@ -170,7 +171,16 @@ def _extract_description(lines: List[str]) -> str | None:
         paragraph.append(stripped)
     if not paragraph:
         return None
-    return " ".join(paragraph)
+    return _normalize_description_text(" ".join(paragraph))
+
+
+_MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _normalize_description_text(text: str) -> str:
+    """Return ``text`` with inline markdown links stripped to plain text."""
+
+    return _MARKDOWN_LINK_PATTERN.sub(r"\1", text)
 
 
 def render_summary(docs: Sequence[PromptDoc]) -> str:

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -4,7 +4,10 @@ import importlib.util
 import sys
 from pathlib import Path
 
-PHRASE = "Use this prompt when verifying tests for automation scripts."
+PHRASE = (
+    "Use this prompt when verifying tests for automation scripts. "
+    "It keeps coverage reviews focused."
+)
 
 
 def load_module():
@@ -39,6 +42,7 @@ Type: evergreen
 One-click: yes
 
 Use this prompt when verifying tests for automation scripts.
+It keeps coverage reviews focused.
 """
     (prompt_dir / "sample.md").write_text(prompt_content, encoding="utf-8")
 
@@ -55,7 +59,8 @@ Use this prompt when verifying tests for automation scripts.
     assert "## sample" in summary.lower()
     assert "Sample Prompt" in summary
     assert "`docs/prompts/sample.md`" in summary
-    assert expected_phrase in summary
+    normalized_summary = " ".join(summary.split())
+    assert expected_phrase in normalized_summary
 
     repos_file = tmp_path / "repos.txt"
     repos_file.write_text(str(repo_root.resolve()), encoding="utf-8")

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -207,3 +207,19 @@ def test_description_strips_markdown_links(tmp_path):
     summary = module.render_summary([doc])
     assert "[propagate.md](" not in summary
     assert "External docs live at Wove." in " ".join(summary.split())
+
+
+def test_description_stops_at_first_blank_line():
+    module = load_module()
+
+    lines = [
+        "Type: evergreen",
+        "",
+        "First sentence.",
+        "",
+        "Second paragraph should be ignored.",
+    ]
+
+    description = module._extract_description(lines)
+
+    assert description == "First sentence."

--- a/tests/test_prompt_docs_summary.py
+++ b/tests/test_prompt_docs_summary.py
@@ -191,18 +191,24 @@ def test_description_strips_markdown_links(tmp_path):
                 "# Link Prompt",
                 "Type: evergreen",
                 "",
-                "Use alongside [propagate.md](propagate.md) to keep summaries stable.",
-                "External docs live at [Wove](https://wove.space).",
+                (
+                    "Use alongside [propagate.md](propagate.md) "
+                    "to keep summaries stable."
+                ),
+                ("External docs live at " "[Wove](https://wove.space)."),
             ]
         ),
         encoding="utf-8",
     )
 
     doc = module.collect_prompt_docs([repo_root])[0]
-    assert doc.description == (
-        "Use alongside propagate.md to keep summaries stable. "
-        "External docs live at Wove."
+    expected_description = " ".join(
+        [
+            "Use alongside propagate.md to keep summaries stable.",
+            "External docs live at Wove.",
+        ]
     )
+    assert doc.description == expected_description
 
     summary = module.render_summary([doc])
     assert "[propagate.md](" not in summary


### PR DESCRIPTION
what: capture multi-line prompt descriptions in summary
why: ensure prompt catalog matches docs and reads cleanly
how to test: pre-commit run --all-files && pytest && ./scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68e40b9be8b8832f8b52bf0e687f400f