### PR TITLE
Add crochet pattern translation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Key features include:
   `rows_per_meter`), width estimators from stitch counts across those units, and
   simple unit conversion helpers.
   See [docs/gauge.md](docs/gauge.md) for examples.
+- A pattern translation CLI (`python -m wove.pattern_cli`) that turns a simple
+  stitch description into G-code-like motion for early crochet experiments.
 - LLM helpers described in [AGENTS.md](AGENTS.md).
 - Sample Codex prompts in [`docs/prompts/codex/automation.md`](docs/prompts/codex/automation.md).
 
@@ -63,3 +65,20 @@ See [AGENTS.md](AGENTS.md) for details on LLM helpers that keep this repo tidy. 
 
 [docs-badge]: https://github.com/futuroptimist/wove/actions/workflows/docs.yml/badge.svg
 [docs-workflow]: https://github.com/futuroptimist/wove/actions/workflows/docs.yml
+# Pattern translation CLI
+
+Use the companion CLI to convert a lightweight stitch description into
+G-code-like motion suitable for early gantry experiments. Feed the CLI either a
+file path or inline text:
+
+```bash
+python -m wove.pattern_cli pattern.txt
+# or
+python -m wove.pattern_cli --text "CHAIN 2\nSINGLE 1" --format json
+```
+
+The DSL accepts commands such as `CHAIN <count>`, `SINGLE <count>`, `DOUBLE
+<count>`, `MOVE <x> <y>`, `TURN [height]`, and `PAUSE <seconds>`. The output is
+G-code-inspired: each stitch generates plunge, yarn-feed, raise, and travel
+moves with comments so you can import the sequence into firmware or simulation
+tools.

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -3,6 +3,7 @@ CLI
 CodeQL
 DEPENDABOT
 Dependabot
+DSL
 DoS
 ESLint
 JS
@@ -43,6 +44,7 @@ js
 macOS
 md
 npm
+nSINGLE
 pipx
 pre
 prettierrc

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Then open `docs/_build/html/index.html` in a browser.
 - [Crochet Basics](crochet-basics.md)
 - [Wove v1c Mechanical Crochet System Design](wove-v1c-design.md)
 - [Robotic Knitting Machine](robotic-knitting-machine.md)
+- [Pattern translation CLI](pattern-cli.md)
 - [Gauge utilities](gauge.md)
 - [Python Style Guide](styleguides/python.md)
 - [Markdown Style Guide](styleguides/markdown.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ crochet-basics
 crochet-tools
 wove-v1c-design
 robotic-knitting-machine
+pattern-cli
 gauge
 learning-resources
 testing

--- a/docs/pattern-cli.md
+++ b/docs/pattern-cli.md
@@ -1,0 +1,69 @@
+# Pattern translation CLI
+
+`wove.pattern_cli` turns a compact crochet stitch description into a
+G-code-like motion sequence that you can stream to firmware or inspection tools.
+The translator focuses on early-stage prototyping rather than production-grade
+path planning, but it demonstrates how a text pattern becomes coordinated motion.
+
+## Supported commands
+
+The domain-specific language (DSL) accepts one command per line. Lines that are
+empty or start with `#` are ignored.
+
+| Command | Description |
+| --- | --- |
+| `CHAIN <count>` | Emit chain stitches spaced evenly along the X axis. |
+| `SINGLE <count>` | Emit single crochet stitches with a deeper plunge and additional yarn feed. |
+| `DOUBLE <count>` | Emit double crochet stitches with a taller pull-up motion. |
+| `MOVE <x> <y>` | Lift safely, then travel to absolute `(x, y)` coordinates in millimeters. |
+| `TURN [height]` | Reset X=0, advance Y to next row, optionally override default 6 mm height. |
+| `PAUSE <seconds>` | Insert a `G4` dwell for the specified number of seconds. |
+
+Values must be positive. Invalid commands or parameters raise `ValueError` and
+stop translation so mistakes surface early.
+
+## Example
+
+Save the following pattern as `pattern.txt`:
+
+```text
+# form a base chain, reposition, and add a single crochet
+CHAIN 3
+PAUSE 0.4
+MOVE 18 5
+TURN 7
+SINGLE 1
+```
+
+Translate it into G-code-like output:
+
+```bash
+python -m wove.pattern_cli pattern.txt
+```
+
+The CLI prints commented commands:
+
+```text
+G21 ; use millimeters
+G90 ; absolute positioning
+G92 X0.00 Y0.00 Z4.00 E0 ; zero axes
+G1 Z-1.50 F600 ; chain stitch 1 of 3: plunge
+G1 E0.50 F300 ; chain stitch 1 of 3: feed yarn
+G1 Z4.00 F600 ; chain stitch 1 of 3: raise
+G0 X5.00 Y0.00 F1200 ; chain stitch 1 of 3: advance
+...
+G4 P400 ; pause for 0.400 s
+G0 X18.00 Y5.00 F1200 ; reposition
+G0 X0.00 Y12.00 F1200 ; turn to next row
+G1 Z-2.00 F600 ; single stitch 1 of 1: plunge
+G1 E2.10 F300 ; single stitch 1 of 1: feed yarn
+G1 Z4.00 F600 ; single stitch 1 of 1: raise
+G0 X4.50 Y12.00 F1200 ; single stitch 1 of 1: advance
+```
+
+Use `--format json` to inspect a structured representation for downstream
+pipelines:
+
+```bash
+python -m wove.pattern_cli --text "CHAIN 1\nDOUBLE 1" --format json
+```

--- a/docs/robotic-knitting-machine.md
+++ b/docs/robotic-knitting-machine.md
@@ -37,3 +37,7 @@ Run the script without arguments to update every model while skipping up-to-date
 Store the exported models alongside their sources to keep hardware and code in sync.
 
 Generated G-code or custom instructions will drive these parts to knit automatically.
+Use [`wove.pattern_cli`](pattern-cli.md) to translate lightweight stitch
+descriptions into G-code-like motion while firmware prototypes are still in
+flux. The CLI complements hardware experiments by showing how text patterns map
+to coordinated gantry moves.

--- a/docs/wove-v1c-design.md
+++ b/docs/wove-v1c-design.md
@@ -80,8 +80,8 @@ Key modules include:
 ### Firmware and Software
 - Base firmware forked from Klipper for flexible motion control and macro scripting.
 - Default config files define axis scaling, stepper currents, and safety limits.
-- Companion Python CLI handles pattern translation from .SVG or custom stitch description to
-  G-code-like motion sequences.
+- Companion Python CLI handles pattern translation from custom stitch descriptions to
+  G-code-like motion sequences (initial DSL implementation complete; .SVG import remains future work).
 - Future roadmap: integrate with browser-based planner for interactive pattern design.
 
 ## Bill of Materials (Initial Release)

--- a/tests/test_pattern_cli.py
+++ b/tests/test_pattern_cli.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+import io
 import json
 import subprocess
 import sys
 
 import pytest
 
-from wove.pattern_cli import PatternTranslator, translate_pattern
+from wove.pattern_cli import (
+    DEFAULT_ROW_HEIGHT,
+    GCodeLine,
+    PatternTranslator,
+    _load_pattern,
+    _write_output,
+    main,
+    parse_args,
+    translate_pattern,
+)
 
 
 def _as_text(lines):
@@ -44,20 +54,119 @@ def test_translate_pattern_basic():
     assert text[-1] == "G0 X4.50 Y11.00 F1200 ; single stitch 1 of 1: advance"
 
 
+def test_translate_pattern_ignores_comments_and_blank_lines():
+    pattern = "\n".join(["", "# comment", "CHAIN 1"])
+    translator = PatternTranslator()
+    lines = translator.translate(pattern)
+    assert any("chain stitch 1 of 1: advance" in line.as_text() for line in lines)
+
+
 @pytest.mark.parametrize(
     "pattern",
     [
         "UNKNOWN 3",
         "CHAIN 0",
+        "CHAIN",
+        "CHAIN two",
         "PAUSE 0",
+        "PAUSE",
+        "PAUSE 1 2",
         "MOVE 3",
+        "MOVE nope 1",
         "TURN -1",
+        "TURN 1 2",
     ],
 )
 def test_translate_pattern_errors(pattern):
     translator = PatternTranslator()
     with pytest.raises(ValueError):
         translator.translate(pattern)
+
+
+def test_turn_without_argument_uses_default_height():
+    pattern = "\n".join(["CHAIN 1", "TURN", "CHAIN 1"])
+    lines = translate_pattern(pattern)
+    text = _as_text(lines)
+    default_turn = f"G0 X0.00 Y{DEFAULT_ROW_HEIGHT:.2f} F1200 ; turn to next row"
+    assert default_turn in text
+    assert text[-1].startswith("G0 X5.00 Y6.00 F1200")
+
+
+def test_ensure_safe_height_emits_command():
+    translator = PatternTranslator()
+    translator._reset_state()
+    translator._z_mm = -1.0
+    translator._ensure_safe_height()
+    assert translator._lines[-1].command.startswith("G1 Z4.00 F600")
+
+
+def test_write_output_handles_files(tmp_path):
+    gcode_lines = [GCodeLine("G21"), GCodeLine("G90", "absolute positioning")]
+    gcode_path = tmp_path / "pattern.gcode"
+    _write_output(gcode_lines, gcode_path, "gcode")
+    assert gcode_path.read_text(encoding="utf-8") == "G21\nG90 ; absolute positioning\n"
+
+    json_path = tmp_path / "pattern.json"
+    _write_output(gcode_lines, json_path, "json")
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload[0]["command"] == "G21"
+    assert payload[1]["comment"] == "absolute positioning"
+
+
+def test_load_pattern_prefers_inline(tmp_path):
+    pattern_path = tmp_path / "pattern.txt"
+    pattern_path.write_text("CHAIN 1", encoding="utf-8")
+    inline = "CHAIN 2"
+    result = _load_pattern(pattern_path, inline)
+    assert result == inline
+
+
+def test_load_pattern_reads_file(tmp_path):
+    pattern_path = tmp_path / "pattern.txt"
+    pattern_path.write_text("CHAIN 1", encoding="utf-8")
+    result = _load_pattern(pattern_path, None)
+    assert result == "CHAIN 1"
+
+
+def test_load_pattern_reads_stdin(monkeypatch):
+    fake_stdin = io.StringIO("CHAIN 1\n")
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    assert _load_pattern(None, None) == "CHAIN 1\n"
+
+
+def test_write_output_stdout_gcode(capsys):
+    lines = [GCodeLine("G21")]
+    _write_output(lines, None, "gcode")
+    captured = capsys.readouterr()
+    assert captured.out == "G21\n"
+
+
+def test_parse_args_variants():
+    defaults = parse_args([])
+    assert defaults.format == "gcode"
+    args = parse_args(["pattern.txt", "--format", "json", "--output", "out.gcode"])
+    assert str(args.pattern) == "pattern.txt"
+    assert args.format == "json"
+    assert str(args.output).endswith("out.gcode")
+
+
+def test_main_stdout_json(capsys):
+    exit_code = main(["--text", "CHAIN 1", "--format", "json"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["command"] == "G21"
+
+
+def test_main_writes_output_file(tmp_path):
+    output_path = tmp_path / "pattern.gcode"
+    exit_code = main([
+        "--text",
+        "CHAIN 1",
+        "--output",
+        str(output_path),
+    ])
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8").startswith("G21")
 
 
 @pytest.mark.parametrize("fmt", ["json", "gcode"])

--- a/tests/test_pattern_cli.py
+++ b/tests/test_pattern_cli.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from wove.pattern_cli import PatternTranslator, translate_pattern
+
+
+def _as_text(lines):
+    return [line.as_text() for line in lines]
+
+
+def test_translate_pattern_basic():
+    pattern = "\n".join(
+        [
+            "CHAIN 2",
+            "PAUSE 0.5",
+            "MOVE 10 5",
+            "TURN 6",
+            "SINGLE 1",
+        ]
+    )
+    lines = translate_pattern(pattern)
+    text = _as_text(lines)
+    assert text[:3] == [
+        "G21 ; use millimeters",
+        "G90 ; absolute positioning",
+        "G92 X0.00 Y0.00 Z4.00 E0 ; zero axes",
+    ]
+    assert text[3] == "G1 Z-1.50 F600 ; chain stitch 1 of 2: plunge"
+    assert text[4] == "G1 E0.50 F300 ; chain stitch 1 of 2: feed yarn"
+    assert text[5] == "G1 Z4.00 F600 ; chain stitch 1 of 2: raise"
+    assert text[6] == "G0 X5.00 Y0.00 F1200 ; chain stitch 1 of 2: advance"
+    assert text[7] == "G1 Z-1.50 F600 ; chain stitch 2 of 2: plunge"
+    assert text[10] == "G0 X10.00 Y0.00 F1200 ; chain stitch 2 of 2: advance"
+    assert "G4 P500 ; pause for 0.500 s" in text
+    assert "G0 X10.00 Y5.00 F1200 ; reposition" in text
+    turn_index = text.index("G0 X0.00 Y11.00 F1200 ; turn to next row")
+    expected_plunge = "G1 Z-2.00 F600 ; single stitch 1 of 1: plunge"
+    assert text[turn_index + 1] == expected_plunge
+    assert text[-1] == "G0 X4.50 Y11.00 F1200 ; single stitch 1 of 1: advance"
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "UNKNOWN 3",
+        "CHAIN 0",
+        "PAUSE 0",
+        "MOVE 3",
+        "TURN -1",
+    ],
+)
+def test_translate_pattern_errors(pattern):
+    translator = PatternTranslator()
+    with pytest.raises(ValueError):
+        translator.translate(pattern)
+
+
+@pytest.mark.parametrize("fmt", ["json", "gcode"])
+def test_pattern_cli_formats(tmp_path, fmt):
+    pattern_path = tmp_path / "pattern.txt"
+    pattern_path.write_text("CHAIN 1\n", encoding="utf-8")
+    command = [
+        sys.executable,
+        "-m",
+        "wove.pattern_cli",
+        str(pattern_path),
+        "--format",
+        fmt,
+    ]
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0
+    if fmt == "json":
+        payload = json.loads(completed.stdout)
+        assert payload[0]["command"] == "G21"
+        assert payload[-1]["comment"].startswith("chain")
+    else:
+        output_lines = completed.stdout.strip().splitlines()
+        assert output_lines[0] == "G21 ; use millimeters"
+        assert output_lines[-1].startswith("G0 X5.00 Y0.00 F1200")
+
+
+def test_pattern_cli_text_input():
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "wove.pattern_cli",
+            "--text",
+            "CHAIN 1\nPAUSE 0.25",
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(completed.stdout)
+    pause = next(line for line in payload if line["command"].startswith("G4"))
+    assert pause["comment"] == "pause for 0.250 s"

--- a/tests/test_pattern_cli.py
+++ b/tests/test_pattern_cli.py
@@ -51,14 +51,19 @@ def test_translate_pattern_basic():
     turn_index = text.index("G0 X0.00 Y11.00 F1200 ; turn to next row")
     expected_plunge = "G1 Z-2.00 F600 ; single stitch 1 of 1: plunge"
     assert text[turn_index + 1] == expected_plunge
-    assert text[-1] == "G0 X4.50 Y11.00 F1200 ; single stitch 1 of 1: advance"
+    assert text[-1] == (
+        "G0 X4.50 Y11.00 F1200 ; single stitch 1 of 1: advance"
+    )
 
 
 def test_translate_pattern_ignores_comments_and_blank_lines():
     pattern = "\n".join(["", "# comment", "CHAIN 1"])
     translator = PatternTranslator()
     lines = translator.translate(pattern)
-    assert any("chain stitch 1 of 1: advance" in line.as_text() for line in lines)
+    assert any(
+        "chain stitch 1 of 1: advance" in line.as_text()
+        for line in lines
+    )
 
 
 @pytest.mark.parametrize(
@@ -87,7 +92,9 @@ def test_turn_without_argument_uses_default_height():
     pattern = "\n".join(["CHAIN 1", "TURN", "CHAIN 1"])
     lines = translate_pattern(pattern)
     text = _as_text(lines)
-    default_turn = f"G0 X0.00 Y{DEFAULT_ROW_HEIGHT:.2f} F1200 ; turn to next row"
+    default_turn = (
+        f"G0 X0.00 Y{DEFAULT_ROW_HEIGHT:.2f} F1200 ; turn to next row"
+    )
     assert default_turn in text
     assert text[-1].startswith("G0 X5.00 Y6.00 F1200")
 
@@ -104,7 +111,8 @@ def test_write_output_handles_files(tmp_path):
     gcode_lines = [GCodeLine("G21"), GCodeLine("G90", "absolute positioning")]
     gcode_path = tmp_path / "pattern.gcode"
     _write_output(gcode_lines, gcode_path, "gcode")
-    assert gcode_path.read_text(encoding="utf-8") == "G21\nG90 ; absolute positioning\n"
+    expected = "G21\nG90 ; absolute positioning\n"
+    assert gcode_path.read_text(encoding="utf-8") == expected
 
     json_path = tmp_path / "pattern.json"
     _write_output(gcode_lines, json_path, "json")
@@ -144,7 +152,9 @@ def test_write_output_stdout_gcode(capsys):
 def test_parse_args_variants():
     defaults = parse_args([])
     assert defaults.format == "gcode"
-    args = parse_args(["pattern.txt", "--format", "json", "--output", "out.gcode"])
+    args = parse_args(
+        ["pattern.txt", "--format", "json", "--output", "out.gcode"]
+    )
     assert str(args.pattern) == "pattern.txt"
     assert args.format == "json"
     assert str(args.output).endswith("out.gcode")

--- a/wove/pattern_cli.py
+++ b/wove/pattern_cli.py
@@ -1,0 +1,324 @@
+"""Translate simple crochet stitch descriptions into G-code-like motion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+SAFE_Z_MM = 4.0
+FABRIC_PLANE_Z_MM = 0.0
+TRAVEL_FEED_RATE = 1200
+PLUNGE_FEED_RATE = 600
+YARN_FEED_RATE = 300
+DEFAULT_ROW_HEIGHT = 6.0
+
+
+@dataclass(frozen=True)
+class GCodeLine:
+    """A single G-code-like instruction with an optional trailing comment."""
+
+    command: str
+    comment: str | None = None
+
+    def as_text(self) -> str:
+        if self.comment:
+            return f"{self.command} ; {self.comment}"
+        return self.command
+
+    def as_dict(self) -> dict[str, str]:
+        data = {"command": self.command}
+        if self.comment:
+            data["comment"] = self.comment
+        return data
+
+
+@dataclass(frozen=True)
+class StitchProfile:
+    """Describe how to render a stitch in the generated motion sequence."""
+
+    name: str
+    spacing_mm: float
+    plunge_depth_mm: float
+    yarn_feed_mm: float
+
+
+STITCH_PROFILES = {
+    "CHAIN": StitchProfile(
+        "CHAIN",
+        spacing_mm=5.0,
+        plunge_depth_mm=1.5,
+        yarn_feed_mm=0.5,
+    ),
+    "SINGLE": StitchProfile(
+        "SINGLE",
+        spacing_mm=4.5,
+        plunge_depth_mm=2.0,
+        yarn_feed_mm=0.6,
+    ),
+    "DOUBLE": StitchProfile(
+        "DOUBLE",
+        spacing_mm=5.5,
+        plunge_depth_mm=2.5,
+        yarn_feed_mm=0.7,
+    ),
+}
+
+
+class PatternTranslator:
+    """Translate pattern lines into a list of :class:`GCodeLine` objects."""
+
+    def __init__(self) -> None:
+        self._lines: List[GCodeLine] = []
+        self._x_mm = 0.0
+        self._y_mm = 0.0
+        self._z_mm = SAFE_Z_MM
+        self._extrusion_mm = 0.0
+
+    def translate(self, source: str) -> List[GCodeLine]:
+        """Translate a stitch description into motion commands."""
+
+        self._reset_state()
+        for line_number, raw_line in enumerate(source.splitlines(), start=1):
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            tokens = stripped.split()
+            command = tokens[0].upper()
+            arguments = tokens[1:]
+            if command in STITCH_PROFILES:
+                count = self._parse_positive_int(
+                    arguments,
+                    line_number,
+                    command,
+                )
+                profile = STITCH_PROFILES[command]
+                self._emit_stitches(profile, count)
+            elif command == "MOVE":
+                self._handle_move(arguments, line_number)
+            elif command == "PAUSE":
+                self._handle_pause(arguments, line_number)
+            elif command == "TURN":
+                self._handle_turn(arguments, line_number)
+            else:
+                message = f"Unknown command '{command}' on line {line_number}"
+                raise ValueError(message)
+        return list(self._lines)
+
+    # Internal helpers -------------------------------------------------
+
+    def _reset_state(self) -> None:
+        self._lines = [
+            GCodeLine("G21", "use millimeters"),
+            GCodeLine("G90", "absolute positioning"),
+            GCodeLine(
+                f"G92 X{self._x_mm:.2f} Y{self._y_mm:.2f} Z{SAFE_Z_MM:.2f} E0",
+                "zero axes",
+            ),
+        ]
+        self._x_mm = 0.0
+        self._y_mm = 0.0
+        self._z_mm = SAFE_Z_MM
+        self._extrusion_mm = 0.0
+
+    def _emit(self, command: str, comment: str | None = None) -> None:
+        self._lines.append(GCodeLine(command, comment))
+
+    def _parse_positive_int(
+        self, arguments: Sequence[str], line_number: int, command: str
+    ) -> int:
+        if not arguments:
+            message = f"{command} on line {line_number} requires a count"
+            raise ValueError(message)
+        try:
+            count = int(arguments[0])
+        except ValueError as error:
+            message = "{} on line {} requires an integer count".format(
+                command,
+                line_number,
+            )
+            raise ValueError(message) from error
+        if count <= 0:
+            message = "{} on line {} requires a positive count".format(
+                command,
+                line_number,
+            )
+            raise ValueError(message)
+        return count
+
+    def _parse_float(
+        self,
+        value: str,
+        line_number: int,
+        command: str,
+    ) -> float:
+        try:
+            return float(value)
+        except ValueError as error:
+            message = "{} on line {} expects numeric values".format(
+                command,
+                line_number,
+            )
+            raise ValueError(message) from error
+
+    def _ensure_safe_height(self) -> None:
+        if self._z_mm != SAFE_Z_MM:
+            command = f"G1 Z{SAFE_Z_MM:.2f} F{PLUNGE_FEED_RATE}"
+            self._emit(command, "raise to safe height")
+            self._z_mm = SAFE_Z_MM
+
+    def _emit_stitches(self, profile: StitchProfile, count: int) -> None:
+        for index in range(1, count + 1):
+            stitch_label = f"{profile.name.lower()} stitch {index} of {count}"
+            plunge_z = FABRIC_PLANE_Z_MM - profile.plunge_depth_mm
+            self._emit(
+                f"G1 Z{plunge_z:.2f} F{PLUNGE_FEED_RATE}",
+                f"{stitch_label}: plunge",
+            )
+            self._z_mm = plunge_z
+            self._extrusion_mm += profile.yarn_feed_mm
+            self._emit(
+                f"G1 E{self._extrusion_mm:.2f} F{YARN_FEED_RATE}",
+                f"{stitch_label}: feed yarn",
+            )
+            self._emit(
+                f"G1 Z{SAFE_Z_MM:.2f} F{PLUNGE_FEED_RATE}",
+                f"{stitch_label}: raise",
+            )
+            self._z_mm = SAFE_Z_MM
+            self._x_mm += profile.spacing_mm
+            self._emit(
+                f"G0 X{self._x_mm:.2f} Y{self._y_mm:.2f} F{TRAVEL_FEED_RATE}",
+                f"{stitch_label}: advance",
+            )
+
+    def _handle_move(self, arguments: Sequence[str], line_number: int) -> None:
+        if len(arguments) < 2:
+            message = f"MOVE on line {line_number} requires X and Y values"
+            raise ValueError(message)
+        self._ensure_safe_height()
+        x_value = self._parse_float(arguments[0], line_number, "MOVE")
+        y_value = self._parse_float(arguments[1], line_number, "MOVE")
+        self._x_mm = x_value
+        self._y_mm = y_value
+        self._emit(
+            f"G0 X{self._x_mm:.2f} Y{self._y_mm:.2f} F{TRAVEL_FEED_RATE}",
+            "reposition",
+        )
+
+    def _handle_pause(
+        self,
+        arguments: Sequence[str],
+        line_number: int,
+    ) -> None:
+        if len(arguments) != 1:
+            message = "PAUSE on line {} requires exactly one value".format(
+                line_number,
+            )
+            raise ValueError(message)
+        seconds = self._parse_float(arguments[0], line_number, "PAUSE")
+        if seconds <= 0:
+            message = "PAUSE on line {} requires a positive duration".format(
+                line_number
+            )
+            raise ValueError(message)
+        milliseconds = int(round(seconds * 1000))
+        comment = f"pause for {seconds:.3f} s"
+        self._emit(f"G4 P{milliseconds}", comment)
+
+    def _handle_turn(self, arguments: Sequence[str], line_number: int) -> None:
+        if len(arguments) > 1:
+            message = "TURN on line {} accepts at most one value".format(
+                line_number,
+            )
+            raise ValueError(message)
+        self._ensure_safe_height()
+        if arguments:
+            step = self._parse_float(arguments[0], line_number, "TURN")
+        else:
+            step = DEFAULT_ROW_HEIGHT
+        if step <= 0:
+            message = "TURN on line {} requires a positive row height".format(
+                line_number
+            )
+            raise ValueError(message)
+        self._x_mm = 0.0
+        self._y_mm += step
+        self._emit(
+            f"G0 X{self._x_mm:.2f} Y{self._y_mm:.2f} F{TRAVEL_FEED_RATE}",
+            "turn to next row",
+        )
+
+
+def translate_pattern(source: str) -> List[GCodeLine]:
+    """Convenience wrapper for :class:`PatternTranslator`."""
+
+    translator = PatternTranslator()
+    return translator.translate(source)
+
+
+def _load_pattern(path: Path | None, pattern: str | None) -> str:
+    if pattern is not None:
+        return pattern
+    if path is not None:
+        return path.read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def _write_output(
+    lines: Iterable[GCodeLine],
+    output_path: Path | None,
+    fmt: str,
+) -> None:
+    if fmt == "gcode":
+        text = "\n".join(line.as_text() for line in lines) + "\n"
+    else:
+        payload = [line.as_dict() for line in lines]
+        text = json.dumps(payload, indent=2)
+    if output_path is None:
+        sys.stdout.write(text)
+    else:
+        output_path.write_text(text, encoding="utf-8")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    description = "Translate a crochet pattern into G-code-like instructions."
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "pattern",
+        nargs="?",
+        help="Path to a pattern file (defaults to stdin).",
+    )
+    parser.add_argument(
+        "--text",
+        help="Inline pattern text. Overrides the positional file if provided.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Optional file to write output. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("gcode", "json"),
+        default="gcode",
+        help="Output format (default: gcode).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    pattern_path = Path(args.pattern) if args.pattern else None
+    pattern_text = _load_pattern(pattern_path, args.text)
+    lines = translate_pattern(pattern_text)
+    _write_output(lines, args.output, args.format)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI tests
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `wove.pattern_cli` translator to turn simple stitch descriptions into G-code-like motion
- document the new CLI in the README, robotics guide, and a dedicated docs page
- add pytest coverage for the translator and CLI entry point

## Testing
- pre-commit run --all-files
- pytest
- ./scripts/checks.sh *(fails: linkchecker unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e55cdccebc832f986b90beb2d7708b