### PR TITLE
Add spool ring pre-pulse countdown highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ A golden progress ring now wraps that spool, filling around the reel as the
 planner feeds yarn so crews can read completion from across the plaza. The Yarn
 Flow monitor echoes the same percentage so the overlay and hologram agree on
 how much of the planned payout has completed.
+The ring now also pre-pulses as the next yarn feed approaches, lighting up the
+spool moments before the countdown hits zero so operators can anticipate the
+upcoming draw without leaving the hologram.
 When a planner omits a yarn target, the ring now pauses its fill while keeping
 the warning tone active so viewers do not mistake an undefined feed plan for a
 completed payout.

--- a/docs/wove-v1c-design.md
+++ b/docs/wove-v1c-design.md
@@ -68,6 +68,8 @@ ready, neutral, and warning tones so crews can see at a glance when the preview 
 feeds yarn without a declared target. The Yarn Flow panel mirrors the same percentage, highlighting
 when the preview reaches its planned payout and flagging runs that feed fiber without a declared
 target.
+A gentle pre-pulse now ramps around the ring whenever a countdown nears the next yarn feed, giving
+operators a visible heads-up in the hologram before the spool spins.
 A floating yarn-feed progress billboard now hangs above the spool, echoing the fed-versus-planned
 totals directly inside the hologram so visitors can read the numbers without shifting back to the
 overlay. It now also surfaces the next yarn feed countdown so operators can time the upcoming pulse

--- a/tests/test_viewer_spool_animation.py
+++ b/tests/test_viewer_spool_animation.py
@@ -27,3 +27,13 @@ def test_spool_progress_billboard_tracks_planner_totals() -> None:
     assert "spoolProgressLabelController.update" in html
     assert "header: spoolProgressHeader" in html
     assert "detailLines.push('Next feed: Awaiting planner preview…')" in html
+
+
+def test_spool_progress_ring_pre_pulses_for_upcoming_feed() -> None:
+    """The spool progress ring should glow ahead of the next feed pulse."""
+
+    html = VIEWER_HTML.read_text(encoding="utf-8")
+
+    assert "feedPulseHighlight" in html
+    assert "cableChainNextFeedSeconds" in html
+    assert "feedPulseWave" in html

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -7395,6 +7395,14 @@
           const scaledProgress = normalizedProgress * spoolProgressSegments.length;
           const fullSegments = Math.floor(scaledProgress);
           const partialStrength = scaledProgress - fullSegments;
+          const feedPulseHighlight = yarnExtrusionActive
+            ? 1
+            : cableChainNextFeedSeconds !== null &&
+                cableChainRemainingFeeds !== null &&
+                cableChainRemainingFeeds > 0
+              ? THREE.MathUtils.clamp(1 - cableChainNextFeedSeconds / 6, 0, 1)
+              : 0;
+          const feedPulseWave = 0.5 + 0.5 * Math.sin(elapsed * 3.2);
           spoolProgressSegments.forEach((controller, index) => {
             const {
               mesh,
@@ -7414,8 +7422,13 @@
             } else if (index === fullSegments) {
               targetStrength = partialStrength;
             }
+            const highlightedStrength = THREE.MathUtils.clamp(
+              targetStrength + feedPulseHighlight * feedPulseWave * 0.6,
+              0,
+              1,
+            );
             const intensityTarget =
-              baseIntensity + (activeIntensity - baseIntensity) * targetStrength;
+              baseIntensity + (activeIntensity - baseIntensity) * highlightedStrength;
             controller.currentIntensity = THREE.MathUtils.damp(
               controller.currentIntensity ?? baseIntensity,
               intensityTarget,
@@ -7424,7 +7437,7 @@
             );
             material.emissiveIntensity = controller.currentIntensity;
             const opacityTarget =
-              baseOpacity + (activeOpacity - baseOpacity) * targetStrength;
+              baseOpacity + (activeOpacity - baseOpacity) * highlightedStrength;
             controller.currentOpacity = THREE.MathUtils.damp(
               controller.currentOpacity ?? baseOpacity,
               opacityTarget,

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -7060,6 +7060,12 @@
             material.opacity = THREE.MathUtils.clamp(controller.currentOpacity, 0, 1);
           }
         });
+        const upcomingFeedUrgency =
+          cableChainNextFeedSeconds !== null &&
+          cableChainRemainingFeeds !== null &&
+          cableChainRemainingFeeds > 0
+            ? THREE.MathUtils.clamp(1 - cableChainNextFeedSeconds / 6, 0, 1)
+            : 0;
         cableChainChaseControllers.forEach((controller) => {
           const {
             mesh,
@@ -7080,15 +7086,9 @@
             return;
           }
 
-          const upcomingUrgency =
-            cableChainNextFeedSeconds !== null &&
-            cableChainRemainingFeeds !== null &&
-            cableChainRemainingFeeds > 0
-              ? THREE.MathUtils.clamp(1 - cableChainNextFeedSeconds / 6, 0, 1)
-              : 0;
           const speed = yarnExtrusionActive
             ? activeSpeed
-            : THREE.MathUtils.lerp(idleSpeed, approachSpeed, upcomingUrgency);
+            : THREE.MathUtils.lerp(idleSpeed, approachSpeed, upcomingFeedUrgency);
           const updatedTravel = (travel + delta * speed) % 1;
           controller.travel = updatedTravel;
 
@@ -7098,9 +7098,7 @@
             light.position.copy(position);
           }
 
-          const chaseStrength = yarnExtrusionActive
-            ? 1
-            : upcomingUrgency;
+          const chaseStrength = yarnExtrusionActive ? 1 : upcomingFeedUrgency;
           const targetIntensity = THREE.MathUtils.lerp(
             restIntensity,
             activeIntensity,
@@ -7395,13 +7393,7 @@
           const scaledProgress = normalizedProgress * spoolProgressSegments.length;
           const fullSegments = Math.floor(scaledProgress);
           const partialStrength = scaledProgress - fullSegments;
-          const feedPulseHighlight = yarnExtrusionActive
-            ? 1
-            : cableChainNextFeedSeconds !== null &&
-                cableChainRemainingFeeds !== null &&
-                cableChainRemainingFeeds > 0
-              ? THREE.MathUtils.clamp(1 - cableChainNextFeedSeconds / 6, 0, 1)
-              : 0;
+          const feedPulseHighlight = yarnExtrusionActive ? 1 : upcomingFeedUrgency;
           const feedPulseWave = 0.5 + 0.5 * Math.sin(elapsed * 3.2);
           spoolProgressSegments.forEach((controller, index) => {
             const {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
what: pre-pulse the spool progress ring before upcoming feed pulses, update
docs/tests, and mark the viewer bundle as an ES module.
why: match the roadmap callout for spool countdown cues and unblock node import
usage in bounds utilities.
how to test: pre-commit run --all-files; pytest; python scripts/serve_viewer.py
--host 127.0.0.1 --port 0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ea074cbc832fbb14d934ccca456e)