### PR TITLE
✨ : modularize viewer scene bootstrap

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -224,3 +224,11 @@ mockups
 
 LED
 LEDs
+runnable
+UI
+lookups
+Renderer
+globals
+DOM
+renderer
+formatter

--- a/docs/viewer-refactor-plan.md
+++ b/docs/viewer-refactor-plan.md
@@ -20,12 +20,12 @@ viewer/
 │   └── main.css            # Shared styling for overlay panels and status banners
 ├── src/
 │   ├── constants.js        # Shared constants, fallbacks, palette definitions
-│   ├── dom.js              # DOM lookups, event wiring helpers (planned)
+│   ├── dom.js              # DOM lookups, event wiring helpers
 │   ├── loaders/
 │   │   ├── planner.js      # Fetch/parse planner exports, defaults, metadata (planned)
 │   │   └── assets.js       # Static asset loading: textures, models, fonts (planned)
 │   ├── scene/
-│   │   ├── setup.js        # Renderer, camera, controls bootstrap (planned)
+│   │   ├── setup.js        # Renderer, camera, controls bootstrap
 │   │   ├── components.js   # Geometry builders for frames, pedestals, anchors (planned)
 │   │   └── effects.js      # Billboards, glows, pulses, sweep rings (planned)
 │   ├── ui/
@@ -45,8 +45,8 @@ viewer/
 2. **Stabilize entry points**
    - Create `viewer/src/dom.js` to centralize all `getElementById` lookups and reusable event
      wiring helpers (e.g., drag-drop, file input change listeners).
-   - Move renderer/camera/control setup into `viewer/src/scene/setup.js`, exporting a factory that
-     returns `{ renderer, scene, camera, controls }` while keeping configuration in one place.
+   - Renderer/camera/control setup now lives in `viewer/src/scene/setup.js`, exporting a factory
+     that returns `{ renderer, scene, camera, controls }` while keeping configuration in one place.
 
 3. **Module boundaries for logic**
    - Split planner parsing, default application, and bounds comparisons into `viewer/src/loaders/`.
@@ -71,8 +71,8 @@ viewer/
 
 ## Immediate next steps
 - Carve out DOM lookups into `viewer/src/dom.js` and import them in `viewer/main.js`.
-- Move renderer/camera/control bootstrap into `viewer/src/scene/setup.js` and keep the animation
-  loop in `viewer/main.js` temporarily.
+- Keep renderer/camera/control bootstrap centralized in `viewer/src/scene/setup.js` while the
+  animation loop lives in `viewer/main.js` temporarily.
 - Extract overlay tone helpers and formatter utilities so panel updates no longer depend on globals.
 - Align directory naming with the target structure above to minimize diff churn in future sessions.
 

--- a/tests/test_viewer_scene.py
+++ b/tests/test_viewer_scene.py
@@ -92,6 +92,15 @@ def test_pattern_preview_pause_toggle_present() -> None:
     assert "updatePatternPreview(patternPreviewElapsed)" in html
 
 
+def test_viewer_bootstraps_scene_setup_module() -> None:
+    """Renderer/camera bootstrap should live in a shared scene helper."""
+
+    html = load_viewer_bundle()
+
+    assert "from './scene/setup.js'" in html
+    assert "createSceneContext" in html
+
+
 def test_base_chain_row_embeds_machine_profile_axes() -> None:
     """The sample planner asset should include machine profile metadata."""
 

--- a/tests/test_viewer_yarn_feed_detection.py
+++ b/tests/test_viewer_yarn_feed_detection.py
@@ -24,7 +24,11 @@ def extract_function_block(html: str, function_name: str) -> str:
 
     start_of_remainder = start_index + len(start_token)
     remainder_tail = html[start_of_remainder:]
-    next_match = re.search(r"\n\s*function [^(]+\(", remainder_tail, flags=re.MULTILINE)
+    next_match = re.search(
+        r"\n\s*(?:export\s+)?function [^(]+\(|\n\s*import\s",
+        remainder_tail,
+        flags=re.MULTILINE,
+    )
     end_index = (
         start_index + len(start_token) + next_match.start()
         if next_match is not None

--- a/tests/viewer_source.py
+++ b/tests/viewer_source.py
@@ -13,5 +13,8 @@ def load_viewer_bundle() -> str:
     html = (VIEWER_DIR / "index.html").read_text(encoding="utf-8")
     script = (VIEWER_DIR / "src" / "main.js").read_text(encoding="utf-8")
     constants = (VIEWER_DIR / "src" / "constants.js").read_text(encoding="utf-8")
+    scene_setup = (VIEWER_DIR / "src" / "scene" / "setup.js").read_text(
+        encoding="utf-8"
+    )
     feeds = (VIEWER_DIR / "src" / "feeds.js").read_text(encoding="utf-8")
-    return html + script + constants + feeds
+    return html + script + constants + scene_setup + feeds

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -1,8 +1,8 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js';
-import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/controls/OrbitControls.js';
 import { comparePlannerToMachineBounds } from '../bounds.js';
 import { getDom } from './dom.js';
 import { computeYarnFeedIndices } from './feeds.js';
+import { createSceneContext } from './scene/setup.js';
 import {
   boundsComparisonFallbackMessage,
   defaultPatternPreviewDurationSeconds,
@@ -43,14 +43,7 @@ import {
 } from './constants.js';
 import { formatFileSize } from './format.js';
 
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setPixelRatio(window.devicePixelRatio);
-renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.outputColorSpace = THREE.SRGBColorSpace;
-document.body.appendChild(renderer.domElement);
-
-const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x0b0c13);
+const { camera, controls, renderer, scene } = createSceneContext();
 const dom = getDom();
 
 const pointer = new THREE.Vector2();
@@ -160,14 +153,6 @@ const LOWER_RAIL_Y = 0.25;
 const UPPER_RAIL_Y = 4.3;
 const RAIL_THICKNESS = 0.22;
 
-const camera = new THREE.PerspectiveCamera(
-  45,
-  window.innerWidth / window.innerHeight,
-  0.1,
-  500,
-);
-camera.position.set(12, 8, 18);
-
 const currentCameraTarget = new THREE.Vector3(0, 1.2, 0);
 const desiredCameraTarget = currentCameraTarget.clone();
 const desiredCameraPosition = camera.position.clone();
@@ -180,12 +165,6 @@ const cameraMoveDamping = 4.0;
 let userIsControllingCamera = false;
 let cameraWasMovedByControls = false;
 
-const controls = new OrbitControls(camera, renderer.domElement);
-controls.enableDamping = true;
-controls.dampingFactor = 0.05;
-controls.minDistance = 4;
-controls.maxDistance = 60;
-controls.maxPolarAngle = Math.PI * 0.49;
 controls.target.copy(currentCameraTarget);
 
 controls.addEventListener('start', () => {

--- a/viewer/src/scene/setup.js
+++ b/viewer/src/scene/setup.js
@@ -1,0 +1,43 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/controls/OrbitControls.js';
+
+/**
+ * Create the renderer, scene, camera, and controls used by the viewer.
+ *
+ * Keeping the bootstrap logic in one place mirrors the modularization plan in
+ * docs/viewer-refactor-plan.md and keeps main.js focused on the assembly
+ * experience instead of setup boilerplate.
+ */
+export function createSceneContext() {
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  document.body.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0b0c13);
+
+  const camera = new THREE.PerspectiveCamera(
+    45,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    500,
+  );
+  camera.position.set(12, 8, 18);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.minDistance = 4;
+  controls.maxDistance = 60;
+  controls.maxPolarAngle = Math.PI * 0.49;
+
+  return {
+    camera,
+    controls,
+    renderer,
+    scene,
+  };
+}
+

--- a/viewer/src/scene/setup.js
+++ b/viewer/src/scene/setup.js
@@ -40,4 +40,3 @@ export function createSceneContext() {
     scene,
   };
 }
-


### PR DESCRIPTION
what: centralize renderer/camera/controls setup in scene/setup.js
why: align viewer modularization roadmap and keep bootstrap isolated
how to test: pre-commit run --all-files; pytest; ./scripts/checks.sh;
  python scripts/serve_viewer.py --host 127.0.0.1 --port 0
Refs: #none

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d220f3cc832fbb0fe0b5e06e3636)