### PR TITLE
✨ : – Extract viewer tone helper module

### DIFF
--- a/docs/viewer-refactor-plan.md
+++ b/docs/viewer-refactor-plan.md
@@ -39,6 +39,8 @@ viewer/
 - Renderer, scene, camera, and control bootstrap now live in `viewer/src/scene/setup.js`, returning
   `{ renderer, scene, camera, controls }` so future refactors can import the shared defaults instead
   of rebuilding the config inline.
+- Overlay tone helpers now live in `viewer/src/ui/tones.js`, keeping panel tone updates reusable
+  while `main.js` continues to shrink.
 
 ## Migration phases
 1. **Extract shared assets (done)**
@@ -78,7 +80,8 @@ viewer/
 - Carve out DOM lookups into `viewer/src/dom.js` and import them in `viewer/main.js`.
 - Reuse the shared bootstrap in `viewer/src/scene/setup.js` while the animation loop lives in
   `viewer/main.js` temporarily.
-- Extract overlay tone helpers and formatter utilities so panel updates no longer depend on globals.
+- Extract formatter utilities so panel updates no longer depend on globals and keep slim tone usage
+  alongside the shared helper.
 - Align directory naming with the target structure above to minimize diff churn in future sessions.
 
 ## Testing expectations

--- a/tests/test_viewer_tone_helpers.py
+++ b/tests/test_viewer_tone_helpers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .viewer_source import VIEWER_DIR
+
+
+def test_viewer_tone_helper_module_exists() -> None:
+    """Shared tone helpers should live in the ui module for reuse."""
+
+    tone_helper = VIEWER_DIR / "src" / "ui" / "tones.js"
+
+    assert tone_helper.exists()
+
+    content = tone_helper.read_text(encoding="utf-8")
+    assert "export function setTone" in content
+
+
+def test_viewer_imports_shared_tone_helper() -> None:
+    """The main viewer module should import the shared tone helper."""
+
+    main_module = (VIEWER_DIR / "src" / "main.js").read_text(encoding="utf-8")
+
+    assert "from './ui/tones.js'" in main_module
+    assert "function setTone" not in main_module

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -41,6 +41,7 @@ import {
   yarnFlowUpcomingFallbackMessage,
 } from './constants.js';
 import { formatFileSize } from './format.js';
+import { setTone } from './ui/tones.js';
 
 const { renderer, scene, camera, controls } = createViewerScene();
 const dom = getDom();
@@ -1680,18 +1681,6 @@ function updatePlannerMetadataPanel(metadata) {
     listItem.textContent = `${label}: ${value}`;
     dom.plannerMetadataListElement.appendChild(listItem);
   });
-}
-
-function setTone(element, tone) {
-  if (!element) {
-    return;
-  }
-
-  if (tone) {
-    element.dataset.tone = tone;
-  } else if (element.dataset && element.dataset.tone) {
-    delete element.dataset.tone;
-  }
 }
 
 function updatePatternPlaybackUi() {

--- a/viewer/src/ui/tones.js
+++ b/viewer/src/ui/tones.js
@@ -5,7 +5,7 @@ export function setTone(element, tone) {
 
   if (tone) {
     element.dataset.tone = tone;
-  } else if (element.dataset && element.dataset.tone) {
+  } else if (element.dataset.tone) {
     delete element.dataset.tone;
   }
 }

--- a/viewer/src/ui/tones.js
+++ b/viewer/src/ui/tones.js
@@ -1,0 +1,11 @@
+export function setTone(element, tone) {
+  if (!element) {
+    return;
+  }
+
+  if (tone) {
+    element.dataset.tone = tone;
+  } else if (element.dataset && element.dataset.tone) {
+    delete element.dataset.tone;
+  }
+}


### PR DESCRIPTION
what: move the viewer tone helper into viewer/src/ui/tones.js, add regression tests, and update the modularization roadmap.
why: keep overlay tone updates reusable while continuing the viewer refactor plan.
how to test: pre-commit run --all-files; pytest; python scripts/serve_viewer.py --host 127.0.0.1 --port 0; ./scripts/checks.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f2a4133c832fb98d6537a5691366)