### PR TITLE
Surface missing bounds axes in viewer status

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ envelope now also calls out the extrusion range, making it obvious when
 E-axis limits differ from the gantry travel. Bounds checks now compare the
 extrusion axis too, warning when yarn-feed envelopes outgrow the machine
 profile limits.
+The bounds comparison panel now spells out which planner or machine axes are
+missing travel limits so you can patch the export quickly when a comparison is
+unavailable.
 Translucent travel-envelope cages now float above the gantry to mirror the
 planner bounds and the machine profile envelope directly inside the hologram.
 The outer cage shifts to amber whenever planner envelopes exceed the machine

--- a/tests/test_bounds_js.py
+++ b/tests/test_bounds_js.py
@@ -57,3 +57,32 @@ def test_bounds_comparison_accepts_uppercase_axes() -> None:
     assert result["missingMachine"] is False
     assert result["fits"] is True
     assert result["exceeding"] == []
+
+
+def test_bounds_missing_axes_messages_include_axis_lists() -> None:
+    """Missing-axis status lines should name the absent planner/machine bounds."""
+
+    script = textwrap.dedent(
+        """
+        import { formatMissingBoundsMessage } from './viewer/bounds.js';
+
+        const machineText = formatMissingBoundsMessage('machine', ['x', 'e']);
+        const plannerText = formatMissingBoundsMessage('planner', ['y', 'z']);
+        const fallbackMachine = formatMissingBoundsMessage('machine');
+        const fallbackPlanner = formatMissingBoundsMessage('planner', []);
+
+        console.log(JSON.stringify({
+          machine: machineText,
+          planner: plannerText,
+          fallbackMachine,
+          fallbackPlanner,
+        }));
+        """
+    )
+
+    result = run_node(script)
+
+    assert "missing bounds for: X, E" in result["machine"]
+    assert "planner export missing bounds for: Y, Z" in result["planner"]
+    assert result["fallbackMachine"].endswith("compare envelopes.")
+    assert result["fallbackPlanner"].endswith("bounds metadata.")

--- a/tests/test_bounds_js.py
+++ b/tests/test_bounds_js.py
@@ -86,3 +86,23 @@ def test_bounds_missing_axes_messages_include_axis_lists() -> None:
     assert "planner export missing bounds for: Y, Z" in result["planner"]
     assert result["fallbackMachine"].endswith("compare envelopes.")
     assert result["fallbackPlanner"].endswith("bounds metadata.")
+
+
+def test_bounds_missing_axes_defaults_to_generic_message() -> None:
+    """Default messages should be generic when the kind is not recognized."""
+
+    script = textwrap.dedent(
+        """
+        import { formatMissingBoundsMessage } from './viewer/bounds.js';
+
+        const unknown = formatMissingBoundsMessage('unknown', ['x']);
+        const emptyKind = formatMissingBoundsMessage(undefined, ['y']);
+
+        console.log(JSON.stringify({ unknown, emptyKind }));
+        """
+    )
+
+    result = run_node(script)
+
+    assert result["unknown"] == "Bounds check unavailable."
+    assert result["emptyKind"] == "Bounds check unavailable."

--- a/viewer/bounds.js
+++ b/viewer/bounds.js
@@ -98,3 +98,28 @@ export function comparePlannerToMachineBounds(plannerBounds, machineBounds) {
     details,
   };
 }
+
+export function formatMissingBoundsMessage(kind, axes = []) {
+  const normalizedAxes = Array.isArray(axes)
+    ? axes
+        .map((axis) => (typeof axis === 'string' ? axis.trim() : ''))
+        .filter((axis) => axis.length > 0)
+        .map((axis) => axis.toUpperCase())
+    : [];
+
+  if (kind === 'machine') {
+    const suffix = normalizedAxes.length > 0
+      ? `missing bounds for: ${normalizedAxes.join(', ')}`
+      : 'include machine_profile axis limits to compare envelopes';
+    return `Bounds check unavailable — ${suffix}.`;
+  }
+
+  if (kind === 'planner') {
+    const suffix = normalizedAxes.length > 0
+      ? `planner export missing bounds for: ${normalizedAxes.join(', ')}`
+      : 'planner export missing bounds metadata';
+    return `Bounds check unavailable — ${suffix}.`;
+  }
+
+  return 'Bounds check unavailable.';
+}

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -1,5 +1,5 @@
 import { THREE, createViewerScene } from './scene/setup.js';
-import { comparePlannerToMachineBounds } from '../bounds.js';
+import { comparePlannerToMachineBounds, formatMissingBoundsMessage } from '../bounds.js';
 import { getDom } from './dom.js';
 import { computeYarnFeedIndices } from './feeds.js';
 import {
@@ -1213,15 +1213,19 @@ function updateBoundsComparisonPanel(plannerBounds, machineBounds, comparison = 
   }
 
   if (details.missingMachine) {
-    dom.boundsComparisonElement.textContent =
-      'Bounds check unavailable — include machine_profile axis limits to compare envelopes.';
+    dom.boundsComparisonElement.textContent = formatMissingBoundsMessage(
+      'machine',
+      details.missingMachineAxes,
+    );
     setTone(dom.boundsComparisonElement, 'warning');
     return;
   }
 
   if (details.missingPlanner) {
-    dom.boundsComparisonElement.textContent =
-      'Bounds check unavailable — planner export missing bounds metadata.';
+    dom.boundsComparisonElement.textContent = formatMissingBoundsMessage(
+      'planner',
+      details.missingPlannerAxes,
+    );
     setTone(dom.boundsComparisonElement, 'warning');
     return;
   }


### PR DESCRIPTION
what: add helper to format missing bounds messages and cover with tests
why: keep bounds panel actionable by naming planner/machine gaps
how to test: pre-commit run --all-files; pytest; ./scripts/checks.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f2a4133c832fb98d6537a5691366)