### PR TITLE
✨ : – keep countdown pacing visible while paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ pinning the next two feed pulses beside the reel so plaza visitors keep the
 upcoming extrusion timing in view even when the overlay is hidden.
 The ribbon now stacks the cycle pacing callout beneath the countdown so elapsed and
 remaining seconds stay visible from the hologram without opening the overlay.
+Cycle pacing now stays visible even when the preview is paused, stacking the pause
+reminder after the timing callout so crews always see both the frozen countdown and the loop
+timing.
 When a planner omits a yarn target, the ring now pauses its fill while keeping
 the warning tone active so viewers do not mistake an undefined feed plan for a
 completed payout.

--- a/tests/test_viewer_pattern_preview.py
+++ b/tests/test_viewer_pattern_preview.py
@@ -187,5 +187,9 @@ def test_spool_countdown_ribbon_surfaces_cycle_pacing() -> None:
     assert "spoolProgressCountdownFallbackMessage" in html
     assert "yarnFlowCycleFallbackMessage" in html
     assert "const countdownLines = [lastSpoolCountdownSummary];" in html
+    assert "if (lastSpoolCycleTimingDetail)" in html
     assert "countdownLines.push(lastSpoolCycleTimingDetail);" in html
+    assert "if (patternPreviewPaused)" in html
+    assert "countdownLines.push(spoolCountdownPausedMessage);" in html
+    assert "else if (lastSpoolCycleTimingDetail)" not in html
     assert "lastSpoolCycleTimingDetail = yarnFlowCycleFallbackMessage;" in html

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -2151,13 +2151,14 @@ function refreshSpoolCountdownLabel() {
     : lastSpoolCountdownToneSource === 'warning'
       ? 'warning'
       : lastSpoolCountdownExtrusionActive
-        ? 'ready'
-        : 'info';
+      ? 'ready'
+      : 'info';
   const countdownLines = [lastSpoolCountdownSummary];
+  if (lastSpoolCycleTimingDetail) {
+    countdownLines.push(lastSpoolCycleTimingDetail);
+  }
   if (patternPreviewPaused) {
     countdownLines.push(spoolCountdownPausedMessage);
-  } else if (lastSpoolCycleTimingDetail) {
-    countdownLines.push(lastSpoolCycleTimingDetail);
   }
 
   spoolCountdownLabelController.update({


### PR DESCRIPTION
What: keep the spool countdown ribbon showing cycle pacing while
paused, update docs, and refresh the countdown test coverage.

Why: pause mode hid loop timing even though the viewer copy said it
would stay visible.

How to test: pre-commit run --all-files; pytest; python
scripts/serve_viewer.py --host 127.0.0.1 --port 0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f2a4133c832fb98d6537a5691366)