### PR TITLE
Extract roadmap overlay update into shared `viewer/src/ui/overlay.js`

### DIFF
--- a/docs/viewer-refactor-plan.md
+++ b/docs/viewer-refactor-plan.md
@@ -41,6 +41,8 @@ viewer/
   of rebuilding the config inline.
 - Overlay tone helpers now live in `viewer/src/ui/tones.js`, keeping panel tone updates reusable
   while `main.js` continues to shrink.
+- Roadmap overlay updates now live in `viewer/src/ui/overlay.js`, allowing the main scene logic to
+  import a focused helper when pedestals are selected.
 
 ## Migration phases
 1. **Extract shared assets (done)**

--- a/tests/test_viewer_html.py
+++ b/tests/test_viewer_html.py
@@ -21,6 +21,15 @@ def test_viewer_exposes_roadmap_panel() -> None:
         assert snippet in viewer_html
 
 
+def test_viewer_roadmap_overlay_helper() -> None:
+    """Ensure the roadmap overlay helper is part of the viewer bundle."""
+
+    viewer_html = _load_viewer_html()
+
+    assert "export function updateRoadmapPanel" in viewer_html
+    assert "roadmapTitleElement" in viewer_html
+
+
 def test_viewer_declares_product_clusters() -> None:
     """Ensure the viewer script ships the product cluster pedestals."""
 

--- a/tests/viewer_source.py
+++ b/tests/viewer_source.py
@@ -14,4 +14,5 @@ def load_viewer_bundle() -> str:
     script = (VIEWER_DIR / "src" / "main.js").read_text(encoding="utf-8")
     constants = (VIEWER_DIR / "src" / "constants.js").read_text(encoding="utf-8")
     feeds = (VIEWER_DIR / "src" / "feeds.js").read_text(encoding="utf-8")
-    return html + script + constants + feeds
+    overlay = (VIEWER_DIR / "src" / "ui" / "overlay.js").read_text(encoding="utf-8")
+    return html + script + constants + feeds + overlay

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -7670,6 +7670,7 @@ function selectCluster(cluster) {
     activeCluster = null;
     selectionRingGroup.visible = false;
     updateRoadmapPanel(
+      dom,
       'Assembly Roadmap',
       'Select a product cluster to learn how it advances the automation journey.',
     );
@@ -7695,7 +7696,7 @@ function selectCluster(cluster) {
   if (selectionSweep) {
     selectionSweep.rotation.y = 0;
   }
-  updateRoadmapPanel(cluster.userData.name, cluster.userData.roadmap);
+  updateRoadmapPanel(dom, cluster.userData.name, cluster.userData.roadmap);
 
   cluster.getWorldPosition(clusterFocusPosition);
   const baseFocusHeight = cluster.userData.selectionHeight ?? selectionRingHeight;

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -42,6 +42,7 @@ import {
 } from './constants.js';
 import { formatFileSize } from './format.js';
 import { setTone } from './ui/tones.js';
+import { updateRoadmapPanel } from './ui/overlay.js';
 
 const { renderer, scene, camera, controls } = createViewerScene();
 const dom = getDom();
@@ -7663,11 +7664,6 @@ function populateProductLines() {
 
 populateProductLines();
 loadPlannerPreviewFromSource();
-
-function updateRoadmapPanel(title, description) {
-  dom.roadmapTitleElement.textContent = title;
-  dom.roadmapDescriptionElement.textContent = description;
-}
 
 function selectCluster(cluster) {
   if (!cluster) {

--- a/viewer/src/ui/overlay.js
+++ b/viewer/src/ui/overlay.js
@@ -1,0 +1,8 @@
+export function updateRoadmapPanel(dom, title, description) {
+  if (!dom || !dom.roadmapTitleElement || !dom.roadmapDescriptionElement) {
+    return;
+  }
+
+  dom.roadmapTitleElement.textContent = title ?? '';
+  dom.roadmapDescriptionElement.textContent = description ?? '';
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication in the viewer by moving the roadmap panel DOM updates out of the large `main.js` file into a focused helper. 
- Follow the viewer refactor plan to make UI overlay updates reusable and easier to test and evolve. 
- Make the roadmap update code importable so other modules can drive the panel without touching `main.js`.

### Description

- Added `viewer/src/ui/overlay.js` exporting `updateRoadmapPanel(dom, title, description)` to centralize roadmap panel updates. 
- Wired the new helper into `viewer/src/main.js` and removed the inlined `updateRoadmapPanel` function there. 
- Updated `tests/viewer_source.py` to include the new overlay module in the bundled viewer source used by tests. 
- Added `tests/test_viewer_html.py::test_viewer_roadmap_overlay_helper` and documented the change in `docs/viewer-refactor-plan.md`.

### Testing

- Ran `pre-commit run --all-files` and hooks completed (format checks and project checks passed). 
- Ran `pytest` and the full test suite passed (`537 passed`). 
- Ran `./scripts/checks.sh` which executed project checks and tests; it completed but reported `linkchecker` missing in the environment as a non-fatal warning. 
- Attempted `npm run test:ci` which failed because the repository does not define a `test:ci` npm script (reported and left unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096dfb100832fbef548a8bc740c1e)