### PR TITLE
Pause yarn-flow visuals when Pattern Studio preview is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ line so mm/s pacing stays visible directly from the hologram.
 Tap Space or use the Pause preview control in the overlay to freeze the Pattern
 Studio hologram while keeping the spool countdown ribbon and Yarn Flow panels
 visible.
+Pausing the preview also freezes the PTFE tube pulse texture and bead queue so
+the flow cues hold their place while the hologram is stopped.
 A pair of cooling fans—the electronics bay exhaust and the hook-carriage
 mount—idle with a gentle spin and ramp up whenever the yarn feed engages, so the
 viewer keeps thermal cues in step with spool choreography.

--- a/docs/wove-v1c-design.md
+++ b/docs/wove-v1c-design.md
@@ -62,6 +62,8 @@ overview before fading once the feed cycle pauses.
 The viewer now also renders the optional filament break sensor as a glowing inline checkpoint,
 brightening with each yarn feed so builders can see exactly where to drop the detector into the
 PTFE run before wiring hardware.
+Pausing the Pattern Studio preview freezes the PTFE pulse texture and bead queue so the flow
+path stays locked in place while the hologram is held.
 The supply spool now spins in the hologram whenever yarn is extruding so teams can watch fiber
 unwind from the source while the tube pulses, then glides to a stop when feed events pause so idle
 segments stay calm.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "echo 'no JS lint defined'",
     "format:check": "echo 'no JS formatter defined'",
-    "test": "node viewer/tests/run-tests.js"
+    "test": "node viewer/tests/run-tests.js",
+    "test:ci": "node viewer/tests/run-tests.js"
   }
 }

--- a/tests/test_viewer_scene.py
+++ b/tests/test_viewer_scene.py
@@ -296,6 +296,17 @@ def test_viewer_mentions_selection_ring_glow() -> None:
     assert selection_ring_copy in html
 
 
+def test_preview_pause_freezes_yarn_flow_motion() -> None:
+    """Pausing the preview should freeze yarn flow pulses and beads."""
+
+    html = load_viewer_bundle()
+
+    assert "const previewDelta = patternPreviewPaused ? 0 : delta;" in html
+    assert "patternPreviewElapsed * speed" in html
+    assert "previewDelta * controller.speed" in html
+    assert "currentTravel + previewDelta * speed" in html
+
+
 def test_anchor_pucks_sequence_glow() -> None:
     """Anchor pucks should document the sequential guidance animation."""
 

--- a/viewer/src/main.js
+++ b/viewer/src/main.js
@@ -7822,6 +7822,7 @@ const clock = new THREE.Clock();
 function animate() {
   const delta = clock.getDelta();
   const elapsed = clock.elapsedTime;
+  const previewDelta = patternPreviewPaused ? 0 : delta;
   if (!patternPreviewPaused) {
     patternPreviewElapsed += delta;
   }
@@ -8389,7 +8390,8 @@ function animate() {
     if (!controller.texture || !controller.material) {
       return;
     }
-    controller.texture.offset.x = (controller.texture.offset.x + delta * controller.speed) % 1;
+    controller.texture.offset.x =
+      (controller.texture.offset.x + previewDelta * controller.speed) % 1;
     const target = yarnExtrusionActive
       ? controller.activeIntensity
       : controller.restIntensity;
@@ -8420,7 +8422,7 @@ function animate() {
     }
 
     const speed = yarnExtrusionActive ? activeSpeed : idleSpeed;
-    const travel = (offset + elapsed * speed) % 1;
+    const travel = (offset + patternPreviewElapsed * speed) % 1;
     if (point) {
       curve.getPointAt(travel, point);
       mesh.position.copy(point);
@@ -8465,7 +8467,7 @@ function animate() {
 
     const speed = yarnExtrusionActive ? activeSpeed : idleSpeed;
     const currentTravel = typeof controller.travel === 'number' ? controller.travel : 0;
-    const updatedTravel = (currentTravel + delta * speed) % 1;
+    const updatedTravel = (currentTravel + previewDelta * speed) % 1;
     controller.travel = updatedTravel;
 
     if (point) {


### PR DESCRIPTION
### Motivation
- Keep the Three.js hologram visually consistent when the Pattern Studio preview is paused by freezing motion cues tied to the preview timeline.
- Make documentation accurate by describing the new pause behavior in the viewer and design docs.
- Add a small regression test to prevent accidental reversion of the pause behavior.
- Provide a convenient npm alias for CI-style viewer tests.

### Description
- Stop PTFE tube texture scrolling and bead/pulse travel when the preview is paused by introducing `previewDelta` and using it in `viewer/src/main.js` to drive yarn-flow motion updates.
- Update `README.md` and `docs/wove-v1c-design.md` to document that pausing the preview freezes the PTFE pulse texture and bead queue.
- Add a regression test `test_preview_pause_freezes_yarn_flow_motion` in `tests/test_viewer_scene.py` that asserts the new timing guards exist in the bundled viewer source.
- Add an npm `test:ci` script in `package.json` as an alias to run the viewer JS checks (`node viewer/tests/run-tests.js`).

### Testing
- Ran `npm run lint` and it completed successfully (no JS lint rules defined). 
- Ran `npm run test:ci` and the viewer unit checks passed. 
- Ran `pre-commit run --all-files` and hooks completed successfully. 
- Ran `pytest` and the full Python test suite passed (`537 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096dfb100832fbef548a8bc740c1e)