### PR TITLE
fix: apply black 26.5.1 formatting and pin lint tool versions

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -10,7 +10,7 @@ jobs:
           python-version: '3.x'
       - run: |
           python -m pip install --upgrade pip
-          pip install flake8 isort black
+          pip install flake8==7.3.0 isort==8.0.1 black==26.5.1
           flake8 . --exclude=.venv
           isort --profile black --check-only . --skip .venv
           black --check . --exclude ".venv/"

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install flake8 isort black pytest linkchecker pyspelling
+          pip install flake8==7.3.0 isort==8.0.1 black==26.5.1 pytest linkchecker pyspelling
       - name: Run checks
         run: bash scripts/checks.sh
       - name: Upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install flake8 isort black pytest coverage
+          pip install flake8==7.3.0 isort==8.0.1 black==26.5.1 pytest coverage
       - name: Run checks
         run: ./scripts/checks.sh
       - name: Run tests with coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,5 @@ jobs:
         run: pip install pytest
       - name: Run checks
         run: |
-          pip install flake8 isort black linkchecker
+          pip install flake8==7.3.0 isort==8.0.1 black==26.5.1 linkchecker
           bash scripts/checks.sh

--- a/scripts/update_prompt_docs_summary.py
+++ b/scripts/update_prompt_docs_summary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate a markdown summary of prompt documentation across repositories."""
+
 from __future__ import annotations
 
 import argparse

--- a/tests/test_bounds_js.py
+++ b/tests/test_bounds_js.py
@@ -22,8 +22,7 @@ def run_node(script: str) -> dict:
 def test_bounds_comparison_accepts_uppercase_axes() -> None:
     """Machine profile bounds should be case-insensitive."""
 
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import { comparePlannerToMachineBounds } from './viewer/bounds.js';
 
         const planner = {
@@ -48,8 +47,7 @@ def test_bounds_comparison_accepts_uppercase_axes() -> None:
           fits: comparison.fits,
           exceeding: comparison.exceedingAxes,
         }));
-        """
-    )
+        """)
 
     result = run_node(script)
 
@@ -62,8 +60,7 @@ def test_bounds_comparison_accepts_uppercase_axes() -> None:
 def test_bounds_missing_axes_messages_include_axis_lists() -> None:
     """Missing-axis status lines should name the absent planner/machine bounds."""
 
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import { formatMissingBoundsMessage } from './viewer/bounds.js';
 
         const machineText = formatMissingBoundsMessage('machine', ['x', 'e']);
@@ -77,8 +74,7 @@ def test_bounds_missing_axes_messages_include_axis_lists() -> None:
           fallbackMachine,
           fallbackPlanner,
         }));
-        """
-    )
+        """)
 
     result = run_node(script)
 
@@ -91,16 +87,14 @@ def test_bounds_missing_axes_messages_include_axis_lists() -> None:
 def test_bounds_missing_axes_defaults_to_generic_message() -> None:
     """Default messages should be generic when the kind is not recognized."""
 
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import { formatMissingBoundsMessage } from './viewer/bounds.js';
 
         const unknown = formatMissingBoundsMessage('unknown', ['x']);
         const emptyKind = formatMissingBoundsMessage(undefined, ['y']);
 
         console.log(JSON.stringify({ unknown, emptyKind }));
-        """
-    )
+        """)
 
     result = run_node(script)
 

--- a/tests/test_format_file_size_js.py
+++ b/tests/test_format_file_size_js.py
@@ -20,8 +20,7 @@ def run_node(script: str) -> dict:
 
 
 def test_format_file_size_formats_common_ranges() -> None:
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import { formatFileSize } from './viewer/src/format.js';
 
         const payload = {
@@ -32,8 +31,7 @@ def test_format_file_size_formats_common_ranges() -> None:
         };
 
         console.log(JSON.stringify(payload));
-        """
-    )
+        """)
 
     result = run_node(script)
 
@@ -46,8 +44,7 @@ def test_format_file_size_formats_common_ranges() -> None:
 
 
 def test_format_file_size_handles_small_and_invalid_inputs() -> None:
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import { formatFileSize } from './viewer/src/format.js';
 
         const values = [
@@ -59,8 +56,7 @@ def test_format_file_size_handles_small_and_invalid_inputs() -> None:
         ];
 
         console.log(JSON.stringify({ values }));
-        """
-    )
+        """)
 
     result = run_node(script)
 

--- a/tests/test_machine_profile.py
+++ b/tests/test_machine_profile.py
@@ -53,8 +53,7 @@ def test_load_machine_profile_json(tmp_path):
 
 
 def test_load_machine_profile_yaml(tmp_path):
-    payload = textwrap.dedent(
-        """
+    payload = textwrap.dedent("""
         axes:
           x:
             microstepping: 32
@@ -71,8 +70,7 @@ def test_load_machine_profile_yaml(tmp_path):
             steps_per_mm: 400
             travel_min_mm: -5
             travel_max_mm: 10
-        """
-    )
+        """)
     profile_path = tmp_path / "machine.yaml"
     profile_path.write_text(payload, encoding="utf-8")
     profile = load_machine_profile(profile_path)

--- a/tests/test_update_prompt_docs_summary.py
+++ b/tests/test_update_prompt_docs_summary.py
@@ -13,8 +13,7 @@ def prompt_repo(tmp_path: Path) -> Path:
     (prompt_dir / "b_nested").mkdir(parents=True)
 
     (prompt_dir / "a_prompt.md").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             ---
             slug: sample
             ---
@@ -24,21 +23,16 @@ def prompt_repo(tmp_path: Path) -> Path:
             One-click: no
 
             This is the description for the sample prompt.
-            """
-        ).strip()
-        + "\n",
+            """).strip() + "\n",
         encoding="utf-8",
     )
 
     (prompt_dir / "b_nested" / "prompt.md").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             # Nested Prompt
 
             Content without metadata.
-            """
-        ).strip()
-        + "\n",
+            """).strip() + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
### Motivation

The [Related Projects status badge](https://github.com/futuroptimist#related-projects) on futuroptimist/futuroptimist turned red for this repo's `Lint & Format` check.

### Root cause

`01-lint-format.yml` installs flake8/isort/black unpinned. Black 26.5.1 (current latest, requires Python 3.10+) was released after this repo was last formatted and reformats how multi-line triple-quoted strings passed to `textwrap.dedent()` are wrapped — a real, if cosmetic, drift, not a false positive. flake8/isort were already clean.

### Description

- Reformat the 5 affected files with black 26.5.1.
- Pin `flake8==7.3.0`/`isort==8.0.1`/`black==26.5.1` in all four workflows that install them (`01-lint-format.yml`, `02-tests.yml`, `ci.yml`, `tests.yml`) so a future release can't silently reintroduce this drift. The latter three route through `scripts/checks.sh`, which already treats these as non-blocking (`|| true`), but pinning keeps behavior consistent everywhere.

### Testing

- `flake8 . --exclude=.venv`, `isort --profile black --check-only . --skip .venv`, `black --check . --exclude ".venv/"` with the pinned versions (Python 3.12, matching what CI's `python-version: '3.x'` resolves to) — all clean.
- `pytest` on the 5 reformatted test files — 16/16 pass.